### PR TITLE
Update base SDK image to Ubuntu 24.04

### DIFF
--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -122,5 +122,11 @@ RUN for command in clang clang++ clangd clang-format clang-tidy lld lldb lldb-se
         ln -s "/usr/bin/${command}-18" "/usr/local/bin/${command}"; \
     done && ln -s "/usr/bin/lld-18" "/usr/local/bin/ld.lld";
 
+# Fix Qt6 system packages - missing symlinks in the Ubuntu-provided packages.
+RUN export QT_VERSION=$(qmake6 -query QT_VERSION) && \
+    for directory in /usr/include/x86_64-linux-gnu/qt6/*; do \
+      ln -s ${directory} ${directory}/${QT_VERSION}  >/dev/null 2>&1 || true; \
+    done
+
 # Switch back to interactive prompt, when using apt.
 ENV DEBIAN_FRONTEND dialog

--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -1,12 +1,12 @@
 # Copyright 2024 Igalia S.L.
 # SPDX-License: MIT
 
-FROM ubuntu:23.04
+FROM ubuntu:24.04
 
 LABEL maintainer="webkit-gtk@lists.webkit.org"
 LABEL version="1.0"
 LABEL org.opencontainers.image.title="WebKit SDK"
-LABEL org.opencontainers.image.description="Provides a complete WebKit Gtk/WPE development environment based on Ubuntu 23.04"
+LABEL org.opencontainers.image.description="Provides a complete WebKit Gtk/WPE development environment based on Ubuntu 24.04"
 LABEL org.opencontainers.image.source=https://github.com/Igalia/wkdev-sdk
 
 # Tweakable "make -j <x>" setting.
@@ -63,7 +63,7 @@ RUN dpkg-reconfigure locales
 # Install all dependencies for WebKit/GStreamer/etc in one pass.
 WORKDIR /var/tmp/wkdev-packages
 COPY /required_system_packages/*.lst .
-RUN sed -i '/deb-src/s/^# //' /etc/apt/sources.list && \
+RUN sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources && \
     ${APT_UPDATE} && \
     for list in *.lst; do \
         ${APT_INSTALL} $(sed -e "s/.*#.*//; /^$/d" "${list}"); \
@@ -95,7 +95,7 @@ RUN git clone https://gitlab.gnome.org/GNOME/jhbuild.git && \
 
 # Register basic JHBuild environment
 # TODO: Instead of hardcoding here the values it would be better to
-# explore the possibility of generating it dinamically with "jhbuild shell"
+# explore the possibility of generating it dynamically with "jhbuild shell"
 # when the user enters into the container (or similar), but that may cause
 # issues with the env not exported when someone enter into the
 # container via direct command exec rather than by login
@@ -119,9 +119,8 @@ COPY /rootfs/etc/ccache.conf /etc/ccache.conf
 
 # Convenience symlink for clang tools, the VSCode extension doesn't find these by default.
 RUN for command in clang clang++ clangd clang-format clang-tidy lld lldb lldb-server lldb-vscode; do \
-        ln -s "/usr/bin/${command}-16" "/usr/local/bin/${command}"; \
-    done && ln -s "/usr/bin/lld-16" "/usr/local/bin/ld.lld";
+        ln -s "/usr/bin/${command}-18" "/usr/local/bin/${command}"; \
+    done && ln -s "/usr/bin/lld-18" "/usr/local/bin/ld.lld";
 
 # Switch back to interactive prompt, when using apt.
 ENV DEBIAN_FRONTEND dialog
-

--- a/images/wkdev_sdk/jhbuild/webkit-sdk-deps.modules
+++ b/images/wkdev_sdk/jhbuild/webkit-sdk-deps.modules
@@ -9,7 +9,6 @@
       <dep package="dicts"/>
       <dep package="libwpe"/>
       <dep package="wpebackend-fdo"/>
-      <dep package="gstreamer"/>
       <dep package="sparkle-cdm"/>
       <dep package="libbacktrace"/>
     </dependencies>
@@ -84,8 +83,7 @@
   <meson id="gstreamer" mesonargs="-Dlibnice=enabled -Dpython=enabled -Dintrospection=enabled -Dgst-plugins-bad:microdns=disabled -Dgst-plugins-bad:avtp=disabled -Dexamples=disabled -Dtests=disabled -Ddoc=disabled">
     <branch repo="gstreamer.freedesktop.org"
             checkoutdir="gstreamer"
-            module="gstreamer.git"
-            tag="1.22.6"/>
+            module="gstreamer.git"/>
     <dependencies>
       <dep package="openh264"/>
     </dependencies>

--- a/images/wkdev_sdk/required_system_packages/01-base.lst
+++ b/images/wkdev_sdk/required_system_packages/01-base.lst
@@ -1,4 +1,4 @@
-# Daemon providing dynamic access to debug symbols (/ sources, not yet available on Ubuntu)
+# Daemon providing dynamic access to debug symbols / sources for system packages
 debuginfod
 
 # Container/capabilities support tools

--- a/images/wkdev_sdk/required_system_packages/02-gcc.lst
+++ b/images/wkdev_sdk/required_system_packages/02-gcc.lst
@@ -1,2 +1,2 @@
-# GNU GCC Toolchain (current version: 12)
-gcc-12 g++-12 gdb libc6-dev
+# GNU GCC Toolchain (current version: 14)
+gcc-14 g++-14 gdb libc6-dev

--- a/images/wkdev_sdk/required_system_packages/03-clang.lst
+++ b/images/wkdev_sdk/required_system_packages/03-clang.lst
@@ -1,2 +1,2 @@
-# Clang toolchain (current version: 16)
-clang-16 clangd-16 clang-format-16 clang-tidy-16 lld-16 lldb-16 libstdc++-13-dev
+# Clang toolchain (current version: 18)
+clang-18 clangd-18 clang-format-18 clang-tidy-18 lld-18 lldb-18 libstdc++-14-dev

--- a/scripts/container-only/wkdev-test-host-integration
+++ b/scripts/container-only/wkdev-test-host-integration
@@ -110,6 +110,11 @@ run() {
     run_test "Test PulseAudio: (should work if it works on the host)" \
         pactl info
 
+    # Our self-compiled GStreamer interferes with the system-provided one, avoid that for testing epiphany.
+    unset GST_PLUGIN_PATH_1_0
+    unset GST_PLUGIN_SCANNER
+    unset LD_LIBRARY_PATH
+
     run_test "Test Epiphany browser: (try youtube.com, CSS 3D demos, WebGL, etc.)" \
         epiphany
 }

--- a/scripts/container-only/wkdev-test-host-integration
+++ b/scripts/container-only/wkdev-test-host-integration
@@ -110,11 +110,6 @@ run() {
     run_test "Test PulseAudio: (should work if it works on the host)" \
         pactl info
 
-    # Our self-compiled GStreamer interferes with the system-provided one, avoid that for testing epiphany.
-    unset GST_PLUGIN_PATH_1_0
-    unset GST_PLUGIN_SCANNER
-    unset LD_LIBRARY_PATH
-
     run_test "Test Epiphany browser: (try youtube.com, CSS 3D demos, WebGL, etc.)" \
         epiphany
 }

--- a/utilities/nvidia-gpu.sh
+++ b/utilities/nvidia-gpu.sh
@@ -25,10 +25,9 @@ is_nvidia_gpu_installed() {
     run_command_silent nvidia-smi || return 1
 }
 
-# This distribution also works for 23.04 -- has no official support though.
-get_nvidia_ubuntu_distribution() { echo "ubuntu22.04"; } # -> symlinks to ubuntu18.04, their only packages
+get_nvidia_ubuntu_distribution() { echo "stable/deb"; }
 get_nvidia_host_package() { echo "nvidia-container-toolkit-base"; } # to be installed on host to create CDI specs
-get_nvidia_container_package() { echo "nvidia-utils-525"; }         # to be installed in the container to have 'nvidia-smi' available
+get_nvidia_container_package() { echo "nvidia-utils-550"; }         # to be installed in the container to have 'nvidia-smi' available
 
 get_nvidia_repository_name() { echo "libnvidia-container"; }
 get_nvidia_repository_url() { echo "https://nvidia.github.io/$(get_nvidia_repository_name)"; }


### PR DESCRIPTION
Let's switch from Ubuntu 23.04 -> Ubuntu 24.04.
We need clang18 in the `wkdev-sdk` to be able to build latest WebKit with clang.