### PR TITLE
Build our own sccache v0.8.1 package.

### DIFF
--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -127,5 +127,8 @@ RUN export QT_VERSION=$(qmake6 -query QT_VERSION) && \
       ln -s ${directory} ${directory}/${QT_VERSION}  >/dev/null 2>&1 || true; \
     done
 
+# Build custom sccache version (the Ubuntu provided 0.7.7 package is broken)
+RUN cargo install --root /usr/local --version 0.8.1 --locked sccache
+
 # Switch back to interactive prompt, when using apt.
 ENV DEBIAN_FRONTEND dialog

--- a/images/wkdev_sdk/required_system_packages/04-devtools.lst
+++ b/images/wkdev_sdk/required_system_packages/04-devtools.lst
@@ -2,7 +2,7 @@
 build-essential cmake ninja-build
 
 # Build tools
-icecc ccache sccache
+icecc ccache cargo
 
 # Debugging / profiling / tracing
 valgrind rr perf-tools-unstable systemd-coredump


### PR DESCRIPTION
The system provided Ubuntu v0.7.7 package is broken:

```
📦 nzimmermann@wkdev:~/$ cat foo.cpp
int foo() {{
📦 nzimmermann@wkdev:~/$ /usr/bin/sccache g++ -o foo.o -c foo.cpp foo.cpp: In function 'int foo()':
foo.cpp:1:13: error: expected '}' at end of input
    1 | # 0 "foo.cpp"
      |            ~^
foo.cpp:1:13: error: expected '}' at end of input
    1 | # 0 "foo.cpp"
      |           ~ ^
foo.cpp:1:13: warning: no return statement in function returning non-void [-Wreturn-type]
sccache: Compiler killed by signal 1
📦 nzimmermann@wkdev:~/$ /usr/bin/sccache g++ -o foo.o -c foo.cpp
📦 nzimmermann@wkdev:~/$
```