### PR TITLE
jhbuild: Build libsoup by default

### DIFF
--- a/images/wkdev_sdk/jhbuild/webkit-sdk-deps.modules
+++ b/images/wkdev_sdk/jhbuild/webkit-sdk-deps.modules
@@ -8,6 +8,7 @@
       <dep package="meson"/>
       <dep package="dicts"/>
       <dep package="libwpe"/>
+      <dep package="libsoup"/>
       <dep package="wpebackend-fdo"/>
       <dep package="sparkle-cdm"/>
       <dep package="libbacktrace"/>


### PR DESCRIPTION
This module moves fast enough that it is valuable for us to regularly test it in the SDK.