### PR TITLE
Export PIP_BREAK_SYSTEM_PACKAGES=1 by default.

### DIFF
--- a/images/wkdev_sdk/user_home_directory_defaults/dot-bash_profile
+++ b/images/wkdev_sdk/user_home_directory_defaults/dot-bash_profile
@@ -1,5 +1,8 @@
 export DEBUGINFOD_URLS="https://debuginfod.ubuntu.com"
 
+# Otherwise one has to pass --break-system-packages to python, when installing custom packages.
+export PIP_BREAK_SYSTEM_PACKAGES=1
+
 # wkdev-sdk integration
 export WKDEV_SDK=/wkdev-sdk
 export PATH="${WKDEV_SDK}/scripts:${WKDEV_SDK}/scripts/container-only:$(python3 -m site --user-base)/bin:${PATH}"

--- a/images/wkdev_sdk/user_home_directory_defaults/dot-zprofile
+++ b/images/wkdev_sdk/user_home_directory_defaults/dot-zprofile
@@ -1,5 +1,8 @@
 export DEBUGINFOD_URLS="https://debuginfod.ubuntu.com"
 
+# Otherwise one has to pass --break-system-packages to python, when installing custom packages.
+export PIP_BREAK_SYSTEM_PACKAGES=1
+
 # wkdev-sdk integration
 export WKDEV_SDK=/wkdev-sdk
 export PATH="${WKDEV_SDK}/scripts:${WKDEV_SDK}/scripts/container-only:$(python3 -m site --user-base)/bin:${PATH}"

--- a/images/wkdev_sdk/user_home_directory_defaults/fish-config
+++ b/images/wkdev_sdk/user_home_directory_defaults/fish-config
@@ -1,5 +1,8 @@
 set --export DEBUGINFOD_URLS "https://debuginfod.ubuntu.com"
 
+# Otherwise one has to pass --break-system-packages to python, when installing custom packages.
+set --export PIP_BREAK_SYSTEM_PACKAGES 1
+
 fish_add_path "$(python3 -m site --user-base)/bin"
 
 # wkdev-sdk integration


### PR DESCRIPTION
This avoids the error message when installing python packages, that on Ubuntu you should install the python-xxxx packages instead of using pip3 install, if possible.

When that is set the error is suppressed, and one doesn't need to pass '--break-system-packages' to python manually.