### PR TITLE
scripts: Mount /run/udev for gamepads

### DIFF
--- a/scripts/host-only/wkdev-create
+++ b/scripts/host-only/wkdev-create
@@ -408,8 +408,9 @@ build_podman_create_arguments() {
     # Mount /dev/pts in container (pseudo-terminal support).
     arguments+=("--mount" "type=devpts,destination=/dev/pts")
 
-    # Mount /dev for devices like gamepads
+    # Mount /dev and /run/udev for devices like gamepads
     arguments+=("-v" "/dev/:/dev:rslave")
+    arguments+=("-v" "/run/udev:/run/udev")
 
     # Mount a tmpfs.
     arguments+=("--tmpfs" "/tmp")


### PR DESCRIPTION
To use an Xbox controller via libmanette, `/run/udev` needs to be mounted. Otherwise I see errors such as `openat(AT_FDCWD<..>, "/run/udev/data/c13:63", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)` and the gamepad isn't detected.