### PR TITLE
List libsysprof-capture-4-dev for installation

### DIFF
--- a/images/wkdev_sdk/required_system_packages/04-devtools.lst
+++ b/images/wkdev_sdk/required_system_packages/04-devtools.lst
@@ -8,7 +8,8 @@ icecc ccache cargo
 valgrind rr perf-tools-unstable systemd-coredump
 
 # Documentation
-asciidoc doxygen doxygen-latex doxygen-doxyparse graphviz python3-sphinx devhelp libglib2.0-doc libgtk-4-doc libsoup-3.0-doc
+asciidoc doxygen doxygen-latex doxygen-doxyparse graphviz python3-sphinx
+devhelp libglib2.0-doc libgtk-4-doc libsoup-3.0-doc libsysprof-capture-4-dev
 
 # For WebKit's scripts such as git-webkit
 python3-pip python3-cffi


### PR DESCRIPTION
WebKit uses libsysprof-capture by default to gather runtime profiling data. Currently developer builds use a bundled copy of the library, so provide it in the SDK container to allow switching to always preferring the system-installed copy.

----

This is needed before we can tackle https://bugs.webkit.org/show_bug.cgi?id=277627