### PR TITLE
jhbuild: remove meson

### DIFF
--- a/images/wkdev_sdk/jhbuild/webkit-sdk-deps.modules
+++ b/images/wkdev_sdk/jhbuild/webkit-sdk-deps.modules
@@ -30,15 +30,6 @@
   <repository type="git" name="gitlab.gnome.org"
       href="https://gitlab.gnome.org/"/>
 
-  <distutils id="meson" python3="1">
-    <branch repo="github-tarball"
-            version="1.2.3"
-            module="mesonbuild/meson/releases/download/${version}/meson-${version}.tar.gz"
-            checkoutdir="meson-${version}"
-            hash="sha256:4533a43c34548edd1f63a276a42690fce15bde9409bcf20c4b8fa3d7e4d7cac1">
-    </branch>
-  </distutils>
-
   <meson id="sparkle-cdm">
     <branch repo="github.com"
             checkoutdir="sparkle-cdm"


### PR DESCRIPTION
Meson dependency is not needed in JHBuild modules since the version shipped by the underlying OS (currently, Ubuntu 24.04) is newer than the version stated in JHBuild modules file.

- JHBuild provided meson: 1.2.3
- System provided meson: 1.3.2

```bash
$ apt-cache madison meson
     meson | 1.3.2-1ubuntu1 | http://archive.ubuntu.com/ubuntu noble/universe amd64 Packages
     meson | 1.3.2-1ubuntu1 | http://archive.ubuntu.com/ubuntu noble/universe Sources
```

```bash
$ git log -1 --pretty="%h %ad %ae %s" --date=short 1.2.3
84e437179 2023-10-17 nirbheek@centricul.. Bump versions to 1.2.3 for release
```

```bash
$ git log -1 --pretty="%h %ad %ae %s" --date=short 1.3.2
614d43623 2024-02-07 nirbheek@centricul.. Bump versions to 1.3.2 for release
```