### PR TITLE
jhbuild: update gstreamer to 1.24.6

### DIFF
--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -138,7 +138,10 @@ RUN export QT_VERSION=$(qmake6 -query QT_VERSION) && \
     done
 
 # Check GStreamer plugins are installed.
-RUN gst-inspect-1.0
+RUN gst-inspect-1.0 audiornnoise && \
+    gst-inspect-1.0 cea608tott && \
+    gst-inspect-1.0 livesync && \
+    gst-inspect-1.0 rsrtp
 
 # Switch back to interactive prompt, when using apt.
 ENV DEBIAN_FRONTEND dialog

--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -80,6 +80,16 @@ RUN sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.s
     rm -rf WebKit && \
     ${APT_AUTOREMOVE}
 
+# Add Rust environment.
+ENV RUSTUP_HOME="/opt/rust" \
+    CARGO_HOME="/opt/rust" \
+    PATH="/opt/rust/bin:${PATH}"
+
+RUN rustup default stable && \
+    rustup component remove rust-docs && \
+    cargo install --root /usr/local --version 0.8.1 --locked sccache && \
+    cargo install --root /usr/local cargo-c
+
 # Copy jhbuild helper files and do the initial build & install
 COPY /jhbuild/jhbuildrc /etc/xdg/jhbuildrc
 COPY /jhbuild/webkit-sdk-deps.modules /jhbuild/webkit-sdk-deps.modules
@@ -127,8 +137,8 @@ RUN export QT_VERSION=$(qmake6 -query QT_VERSION) && \
       ln -s ${directory} ${directory}/${QT_VERSION}  >/dev/null 2>&1 || true; \
     done
 
-# Build custom sccache version (the Ubuntu provided 0.7.7 package is broken)
-RUN cargo install --root /usr/local --version 0.8.1 --locked sccache
+# Check GStreamer plugins are installed.
+RUN gst-inspect-1.0
 
 # Switch back to interactive prompt, when using apt.
 ENV DEBIAN_FRONTEND dialog

--- a/images/wkdev_sdk/jhbuild/webkit-sdk-deps.modules
+++ b/images/wkdev_sdk/jhbuild/webkit-sdk-deps.modules
@@ -9,6 +9,7 @@
       <dep package="libwpe"/>
       <dep package="libsoup"/>
       <dep package="wpebackend-fdo"/>
+      <dep package="gstreamer"/>
       <dep package="sparkle-cdm"/>
       <dep package="libbacktrace"/>
       <dep package="sysprof"/>
@@ -94,10 +95,11 @@
     </branch>
   </meson>
 
-  <meson id="gstreamer" mesonargs="-Dlibnice=enabled -Dpython=enabled -Dintrospection=enabled -Dgst-plugins-bad:microdns=disabled -Dgst-plugins-bad:avtp=disabled -Dexamples=disabled -Dtests=disabled -Ddoc=disabled">
+  <meson id="gstreamer" mesonargs="-Dlibnice=enabled -Dpython=enabled -Dintrospection=enabled -Dgst-plugins-bad:microdns=disabled -Dgst-plugins-bad:avtp=disabled -Dexamples=disabled -Dtests=disabled -Ddoc=disabled -Dgtk_doc=disabled -Drs=enabled -Dwebrtc=enabled">
     <branch repo="gstreamer.freedesktop.org"
             checkoutdir="gstreamer"
-            module="gstreamer.git"/>
+            module="gstreamer.git"
+            tag="1.24.6"/>
     <dependencies>
       <dep package="openh264"/>
     </dependencies>

--- a/images/wkdev_sdk/required_system_packages/04-devtools.lst
+++ b/images/wkdev_sdk/required_system_packages/04-devtools.lst
@@ -2,7 +2,7 @@
 build-essential cmake ninja-build
 
 # Build tools
-icecc ccache cargo
+icecc ccache rustup
 
 # Debugging / profiling / tracing
 valgrind rr perf-tools-unstable systemd-coredump

--- a/scripts/container-only/.wkdev-init
+++ b/scripts/container-only/.wkdev-init
@@ -188,6 +188,16 @@ try_setup_permissions_jhbuild_directory() {
 
 }
 
+try_setup_permissions_rust_directory() {
+
+    echo ""
+
+    local rust_directory="/opt/rust"
+    echo "[12/13] Setup rust '${rust_directory}' directory permissions..."
+
+    chown --recursive "${container_user_name}:${container_group_name}" "${rust_directory}" &>/dev/null
+}
+
 try_firstrun_script() {
 
     local user_home
@@ -222,6 +232,7 @@ TASKS=(
     "try_setup_run_user_directory"
     "try_setup_dockerenv_file"
     "try_setup_permissions_jhbuild_directory"
+    "try_setup_permissions_rust_directory"
     "try_firstrun_script"
 )
 

--- a/scripts/container-only/wkdev-test-host-integration
+++ b/scripts/container-only/wkdev-test-host-integration
@@ -110,6 +110,11 @@ run() {
     run_test "Test PulseAudio: (should work if it works on the host)" \
         pactl info
 
+    # Our self-compiled GStreamer interferes with the system-provided one, avoid that for testing epiphany.
+    unset GST_PLUGIN_PATH_1_0
+    unset GST_PLUGIN_SCANNER
+    unset LD_LIBRARY_PATH
+
     run_test "Test Epiphany browser: (try youtube.com, CSS 3D demos, WebGL, etc.)" \
         epiphany
 }


### PR DESCRIPTION
This PR updates JHBuild's gstramer to the same version as Flatpak: 1.24.6. Also, now GStreamer modules 'rs' (Rust) and 'webrtc' are enabled.

When the 'rs' module is enabled, compilation fails with the following error:

```bash
../subprojects/gst-plugins-rs/meson.build:28:2: ERROR: Problem encountered: cargo-c missing, install it with: 'cargo install cargo-c'

A full log can be found at /home/buildbot/workspace/gstreamer/build/meson-logs/meson-log.txt
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
main buildbot@wkdev ~/workspace/gstreamer/build $ cargo install cargo-c
	Updating crates.io index
error: cannot install package `cargo-c 0.10.3+cargo-0.81.0`, it requires rustc 1.78 or newer, while the currently active rustc version is 1.75.0
`cargo-c 0.9.31+cargo-0.78.0` supports rustc 1.75
```
To install a more up-to-date version of 'rustc' I ran the following steps:

```bash
curl https://sh.rustup.rs -sSf | sh
rustup toolchain install nightly
rustup default nightly
source $HOME/.bashrc
```

These step should be run at some point in the container. I don't know where would be the best place to put them.

This change doesn't bring the container SDK to exactly what Flatpak SDK does regarding GStreamer, but after this change the crashes after running layout-tests are solved.

Lastly, this commit: [jhbuild: Do not build custom gstreamer](https://github.com/Igalia/webkit-container-sdk/commit/d7b4374f351b001a8722a780b55fd4d002901563) removed gstreamer from the list of modules to be built via JHBuild since Ubuntu 24.04 provided a more up-to-date version. The commit also unsets several environment variables. I wonder if those variables should be restored?