### PR TITLE
GitHub Actions: Free up more space in CI worker

### DIFF
--- a/.github/workflows/scripts/free_disk_space.sh
+++ b/.github/workflows/scripts/free_disk_space.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Based on: https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
+#
+echo "=============================================================================="
+echo "Freeing up disk space on CI system"
+echo "=============================================================================="
+echo ""
+
+# Before
+echo "Disk space before:"
+df -h
+echo ""
+
+# List packages
+echo "Listing 100 largest packages"
+dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
+echo ""
+
+# Remove packages
+echo ""
+echo "Removing large packages"
+sudo apt-get remove -y '^dotnet-.*'
+sudo apt-get remove -y '^llvm-.*'
+sudo apt-get remove -y 'php.*'
+sudo apt-get remove -y '^mongodb-.*'
+sudo apt-get remove -y '^mysql-.*'
+sudo apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel
+sudo apt-get autoremove -y
+sudo apt-get clean
+echo ""
+echo "Disk space after apt-get:"
+df -h
+echo ""
+
+# Large dirs
+echo "Removing large directories"
+# https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
+sudo rm -rf /usr/share/dotnet/
+sudo rm -rf /usr/local/graalvm/
+sudo rm -rf /usr/local/.ghcup/
+sudo rm -rf /usr/local/share/powershell
+sudo rm -rf /usr/local/share/chromium
+sudo rm -rf /usr/local/lib/android
+sudo rm -rf /opt/ghc
+echo ""
+echo "Disk space after removing large directories:"
+df -h
+echo ""
+
+# https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
+echo "Removing preinstalled tools"
+sudo rm -rf "/usr/local/share/boost"
+sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+echo ""
+
+# After
+echo "Disk space after:"
+df -h
+echo ""

--- a/.github/workflows/scripts/free_disk_space.sh
+++ b/.github/workflows/scripts/free_disk_space.sh
@@ -20,7 +20,6 @@ echo ""
 # Remove packages
 echo ""
 echo "Removing large packages"
-sudo apt-get remove -y '^dotnet-.*'
 sudo apt-get remove -y '^llvm-.*'
 sudo apt-get remove -y 'php.*'
 sudo apt-get remove -y '^mongodb-.*'
@@ -36,13 +35,11 @@ echo ""
 # Large dirs
 echo "Removing large directories"
 # https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
-sudo rm -rf /usr/share/dotnet/
-sudo rm -rf /usr/local/graalvm/
 sudo rm -rf /usr/local/.ghcup/
-sudo rm -rf /usr/local/share/powershell
+sudo rm -rf /usr/local/graalvm/
+sudo rm -rf /usr/local/lib/node_modules
 sudo rm -rf /usr/local/share/chromium
-sudo rm -rf /usr/local/lib/android
-sudo rm -rf /opt/ghc
+sudo rm -rf /usr/local/share/powershell
 echo ""
 echo "Disk space after removing large directories:"
 df -h

--- a/.github/workflows/wkdev-sdk.yml
+++ b/.github/workflows/wkdev-sdk.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: Free disk space
+        run: .github/workflows/scripts/free_disk_space.sh
+
       - name: Build image
         run: |
           source ./register-sdk-on-host.sh


### PR DESCRIPTION
The current `wkdev-sdk.yml` contains an action that frees up space in the GitHub Action CI worker. In addition to that, I want to try out another script that removes even more unnecessary stuff. If the gain is significant, we can keep it.