### PR TITLE
jhbuild: build gstreamer plugin 'dav1ddec'

### DIFF
--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -141,6 +141,7 @@ RUN export QT_VERSION=$(qmake6 -query QT_VERSION) && \
 # Check GStreamer plugins are installed.
 RUN gst-inspect-1.0 audiornnoise && \
     gst-inspect-1.0 cea608tott && \
+    gst-inspect-1.0 dav1ddec && \
     gst-inspect-1.0 livesync && \
     gst-inspect-1.0 rsrtp
 

--- a/images/wkdev_sdk/jhbuild/webkit-sdk-deps.modules
+++ b/images/wkdev_sdk/jhbuild/webkit-sdk-deps.modules
@@ -9,6 +9,7 @@
       <dep package="libwpe"/>
       <dep package="libsoup"/>
       <dep package="wpebackend-fdo"/>
+      <dep package="gst-plugins-rs"/>
       <dep package="gstreamer"/>
       <dep package="sparkle-cdm"/>
       <dep package="libbacktrace"/>
@@ -104,7 +105,7 @@
     </branch>
   </meson>
 
-  <meson id="gstreamer" mesonargs="-Dlibnice=enabled -Dpython=enabled -Dintrospection=enabled -Dgst-plugins-bad:microdns=disabled -Dgst-plugins-bad:avtp=disabled -Dexamples=disabled -Dtests=disabled -Ddoc=disabled -Dgtk_doc=disabled -Drs=enabled -Dwebrtc=enabled">
+  <meson id="gstreamer" mesonargs="-Dlibnice=enabled -Dpython=enabled -Dintrospection=enabled -Dgst-plugins-bad:microdns=disabled -Dgst-plugins-bad:avtp=disabled -Dgst-examples=disabled -Dexamples=disabled -Dtests=disabled -Ddoc=disabled -Dgtk_doc=disabled -Dwebrtc=enabled">
     <branch repo="gstreamer.freedesktop.org"
             checkoutdir="gstreamer"
             module="gstreamer.git"
@@ -116,6 +117,24 @@
     <dependencies>
       <dep package="openh264"/>
     </dependencies>
+  </meson>
+
+  <meson id="dav1d" mesonargs="-Denable_examples=false -Denable_tests=false -Denable_tools=false -Dxxhash_muxer=disabled">
+    <branch repo="github.com"
+            module="videolan/dav1d.git"
+            tag="1.4.2"
+            version="1.4.2" />
+  </meson>
+
+  <meson id="gst-plugins-rs" mesonargs="-Ddoc=disabled -Dexamples=disabled -Dtests=disabled">
+    <dependencies>
+      <dep package="dav1d"/>
+      <dep package="gstreamer"/>
+    </dependencies>
+    <branch repo="gstreamer.freedesktop.org"
+            module="gst-plugins-rs"
+            tag="0.13.1"
+            version="0.13.1" />
   </meson>
 
   <meson id="glib" mesonargs="--localstatedir=/var -Dlibmount=disabled -Dtests=false">


### PR DESCRIPTION
Follow-up to: [jhbuild: update gstreamer to 1.24.6](https://github.com/Igalia/webkit-container-sdk/pull/39)