### PR TITLE
Temporarily disable GStreamer via JHBuild and Rust

### DIFF
--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -80,16 +80,6 @@ RUN sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.s
     rm -rf WebKit && \
     ${APT_AUTOREMOVE}
 
-# Add Rust environment.
-ENV RUSTUP_HOME="/opt/rust" \
-    CARGO_HOME="/opt/rust" \
-    PATH="/opt/rust/bin:${PATH}"
-
-RUN rustup default stable && \
-    rustup component remove rust-docs && \
-    cargo install --root /usr/local --version 0.8.1 --locked sccache && \
-    cargo install --root /usr/local cargo-c
-
 # Copy jhbuild helper files and do the initial build & install
 COPY /jhbuild/jhbuildrc /etc/xdg/jhbuildrc
 COPY /jhbuild/webkit-sdk-deps.modules /jhbuild/webkit-sdk-deps.modules
@@ -136,12 +126,6 @@ RUN export QT_VERSION=$(qmake6 -query QT_VERSION) && \
     for directory in /usr/include/x86_64-linux-gnu/qt6/*; do \
       ln -s ${directory} ${directory}/${QT_VERSION}  >/dev/null 2>&1 || true; \
     done
-
-# Check GStreamer plugins are installed.
-RUN gst-inspect-1.0 audiornnoise && \
-    gst-inspect-1.0 cea608tott && \
-    gst-inspect-1.0 livesync && \
-    gst-inspect-1.0 rsrtp
 
 # Switch back to interactive prompt, when using apt.
 ENV DEBIAN_FRONTEND dialog

--- a/images/wkdev_sdk/jhbuild/webkit-sdk-deps.modules
+++ b/images/wkdev_sdk/jhbuild/webkit-sdk-deps.modules
@@ -9,7 +9,6 @@
       <dep package="libwpe"/>
       <dep package="libsoup"/>
       <dep package="wpebackend-fdo"/>
-      <dep package="gstreamer"/>
       <dep package="sparkle-cdm"/>
       <dep package="libbacktrace"/>
       <dep package="sysprof"/>
@@ -90,10 +89,8 @@
   <meson id="libspiel" mesonargs="-Dtests=false -Ddocs=false -Dlibspeechprovider:docs=false -Dlibspeechprovider:introspection=false">
     <branch repo="github.com"
             checkoutdir="libspiel"
-            module="project-spiel/libspiel"/>
-    <dependencies>
-      <dep package="gstreamer"/>
-    </dependencies>
+            module="project-spiel/libspiel"
+            tag="SPIEL_1_0_1"/>
   </meson>
 
   <meson id="openh264" mesonargs="-Dtests=disabled">

--- a/images/wkdev_sdk/required_system_packages/04-devtools.lst
+++ b/images/wkdev_sdk/required_system_packages/04-devtools.lst
@@ -2,7 +2,7 @@
 build-essential cmake ninja-build
 
 # Build tools
-icecc ccache rustup
+icecc ccache cargo
 
 # Debugging / profiling / tracing
 valgrind rr perf-tools-unstable systemd-coredump

--- a/scripts/container-only/.wkdev-init
+++ b/scripts/container-only/.wkdev-init
@@ -231,7 +231,6 @@ TASKS=(
     "try_setup_run_user_directory"
     "try_setup_dockerenv_file"
     "try_setup_permissions_jhbuild_directory"
-    "try_setup_permissions_rust_directory"
     "try_firstrun_script"
 )
 


### PR DESCRIPTION
The `deploy` step in the GitHub runner is failing due to lack of space in the container:
  - https://github.com/Igalia/webkit-container-sdk/actions/runs/11069214537

Error:

````
[deploy](https://github.com/Igalia/webkit-container-sdk/actions/runs/11069214537/job/30759141454#step:1:39)
You are running out of disk space. The runner will stop working when the machine runs out of disk space. Free space left: 0 MB
````

In order to free up space in the GitHub Runner and successfully complete the `deploy` step, this PR temporarily disables GStreamer in JHBuild (an older version of GStreamer is installed via system libraries) and it also disables Rust.