### PR TITLE
[CI] Switch runner to self-hosted

### DIFF
--- a/.github/workflows/wkdev-sdk.yml
+++ b/.github/workflows/wkdev-sdk.yml
@@ -11,7 +11,7 @@ defaults:
     shell: bash
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted
     steps:
       - name: Set tag name
         run: |
@@ -64,7 +64,7 @@ jobs:
           wkdev-enter --exec -- ./WebKit/Tools/Scripts/build-webkit --gtk --release --generate-project-only
 
   deploy:
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted
     needs: build
     if: github.ref_name == 'main' || startsWith(github.ref_name, 'tag/')
     steps:


### PR DESCRIPTION
Right now, the free GitHub runner is failing in `deploy` step due to lack of space in the runner:
  - https://github.com/Igalia/webkit-container-sdk/actions/runs/11069214537
We would like to switch the runner to self-hosted so we can have more storage space in the container.