### PR TITLE
wkdev-update: Make --verbose the default mode.

### DIFF
--- a/scripts/host-only/wkdev-update
+++ b/scripts/host-only/wkdev-update
@@ -11,7 +11,6 @@ source "${WKDEV_SDK}/utilities/podman.sh"
 
 argsparse_use_option debug        "Enable debug logging for podman (useful to debug container issues)"
 argsparse_use_option trace        "Enable 'xtrace' mode for this script"
-argsparse_use_option =verbose     "Increase verbosity of this script"
 
 argsparse_usage_description="$(cat <<EOF
 << Purpose >>
@@ -35,7 +34,7 @@ try_update_sdk_repository() {
 
     if [ "$(git rev-parse --abbrev-ref HEAD)" = "main" ] && [ -z "$(git status --untracked-files=no --porcelain)" ]; then
         echo "-> Updating Git repository 'wkdev-sdk' located in \${WKDEV_SDK}..."
-        run_command_silent_unless_verbose git pull --rebase || _abort_ "Cannot update wkdev-sdk repository"
+        run_command git pull --rebase || _abort_ "Cannot update wkdev-sdk repository"
     else
         echo "-> Not updating Git repository 'wkdev-sdk' located in \${WKDEV_SDK} - there are local modifications!"
     fi
@@ -148,7 +147,7 @@ update_image() {
 
     echo ""
     echo "-> Updating image '${image_name}'..."
-    run_podman_silent_unless_verbose pull "${image_name}" || _abort_ "Cannot update image '${image_name}'"
+    run_podman pull "${image_name}" || _abort_ "Cannot update image '${image_name}'"
 }
 
 # Main functionality


### PR DESCRIPTION
Fixes issue #55. Remove the --verbose option, and make it default.

This avoids surprises, when the script appears to be stuck, when it's e.g. pulling a new image from ghcr.io -- always show the podman pull output instead.