### PR TITLE
wkdev-enter: Show container log, while waiting for initialization

### DIFF
--- a/scripts/host-only/wkdev-enter
+++ b/scripts/host-only/wkdev-enter
@@ -123,6 +123,13 @@ run() {
 
             echo "   Retry ${retries}/${max_retries} in ${sleep_duration_in_seconds} seconds..."
             sleep ${sleep_duration_in_seconds}
+
+            echo ""
+            echo "   Last 5 lines from container log (invoke 'podman logs ${container_name}' to see the full output):"
+            echo "   ------------------------------------------------------------------"
+            run_podman ${podman_arguments[@]} logs --tail 5 "${container_name}"
+            echo "   ------------------------------------------------------------------"
+            echo ""
         done;
     }
 


### PR DESCRIPTION
Show an excerpt from the container log after waiting for N seconds to try to enter the container.

This helps the user to indicate progress, when entering a freshly created container for the first time (when wkdev-init is running for the first time). At the same time, no output is shown upon successive wkdev-enter commands, since the container is already initialized, and entering it is fast by definition.