### PR TITLE
Improve /dev/log symbolic link setup to only create it if missing (#49)

### DIFF
--- a/scripts/container-only/.wkdev-init
+++ b/scripts/container-only/.wkdev-init
@@ -133,8 +133,15 @@ try_setup_setgid_subuid_files() {
 
 try_setup_journal_dev_log() {
 
-    task_step "Set /dev/log symbolic link to /run/systemd/journal/dev-log ..."
-    sudo ln -sf /run/systemd/journal/dev-log /dev/log
+    task_step "Check if /dev/log exists, if not set symbolic link to /run/systemd/journal/dev-log ..."
+    echo ""
+
+    if [ ! -e /dev/log ]; then
+        sudo ln -s /run/systemd/journal/dev-log /dev/log
+        echo "      -> /dev/log symbolic link created."
+    else
+        echo "      -> /dev/log already exists, skipping symbolic link creation."
+    fi
 }
 
 try_setup_sudoers_file() {


### PR DESCRIPTION
This fixes cases where the symbolic link is already present in the system, such as in the latest Ubuntu images.

If `/dev/log` already exists, the script skips the link creation to avoid the following error message:

```
[9/14] Set /dev/log symbolic link to /run/systemd/journal/dev-log ...
ln: failed to create symbolic link '/dev/log': Permission denied
```

Issue: https://github.com/Igalia/webkit-container-sdk/issues/49