### PR TITLE
Pass argument '--rm' to avoid wkdev-create container name collission

### DIFF
--- a/.github/workflows/wkdev-sdk.yml
+++ b/.github/workflows/wkdev-sdk.yml
@@ -41,15 +41,11 @@ jobs:
 
       - name: Test image
         run: |
-          CONTAINER="wkdev-$(date +%s)"
           source ./register-sdk-on-host.sh
-          wkdev-create --create-home --home ${HOME}/${CONTAINER}-home --verbose --attach --no-pull --name ${CONTAINER}
-          wkdev-enter -n ${CONTAINER} --exec -- git clone --depth=1 https://github.com/WebKit/WebKit.git
-          wkdev-enter -n ${CONTAINER} --exec -- ./WebKit/Tools/Scripts/build-webkit --wpe --release --generate-project-only
-          wkdev-enter -n ${CONTAINER} --exec -- ./WebKit/Tools/Scripts/build-webkit --gtk --release --generate-project-only
-          podman stop ${CONTAINER} || true
-          podman rm ${CONTAINER} || true
-          rm -rf ${HOME}/${CONTAINER}-home
+          wkdev-create --create-home --verbose --attach --no-pull --rm
+          wkdev-enter --exec -- git clone --depth=1 https://github.com/WebKit/WebKit.git
+          wkdev-enter --exec -- ./WebKit/Tools/Scripts/build-webkit --wpe --release --generate-project-only
+          wkdev-enter --exec -- ./WebKit/Tools/Scripts/build-webkit --gtk --release --generate-project-only
 
   deploy:
     runs-on: self-hosted

--- a/scripts/host-only/wkdev-create
+++ b/scripts/host-only/wkdev-create
@@ -85,6 +85,10 @@ process_command_line_arguments() {
     host_hostname="$(hostnamectl hostname)"
     container_hostname="$(basename "${container_name}").${host_hostname}"
 
+    if argsparse_is_option_set "create-home" && -d "${container_user_home}"; then
+        rm -rf "${container_user_home}"
+    fi
+
     # Verify the container home directory is accessible.
     if [ ! -d "${container_user_home}" ]; then
         if ! argsparse_is_option_set "create-home"; then


### PR DESCRIPTION
Follow-up to d347129.

Command `wkdev-create` allows passing argument `--rm` which stops and removes a container in case it already exists. This can be useful to avoid the container name collission, instead of creating a temporal name for the container and stopping and removing it late.

To avoid the home directory collission, `wkdev-create` can delete the home directory in case it already exists and `create-home` was passed as an argument.