### PR TITLE
.gitignore: .sysctl_setting_perf_event_paranoid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .build-done_wkdev-webkit-dependencies
+.sysctl_setting_perf_event_paranoid


### PR DESCRIPTION
That file is created by wkdev-start-profiling and should not be checked in the repository.