### PR TITLE
Silence systemctl messages

### DIFF
--- a/utilities/podman.sh
+++ b/utilities/podman.sh
@@ -89,6 +89,6 @@ is_podman_user_socket_available() {
     [ -S "${podman_socket}" ] || return 1
 
     # ... and it should be controlled by the systemd user session.
-    systemctl status --user podman.socket >/dev/null
+    systemctl status --user podman.socket &>/dev/null
     return ${?}
 }


### PR DESCRIPTION
systemctl status can be noisy if the log has been rotated, showing this message:

> Warning: The unit file, source configuration file or drop-ins of
> podman.socket changed on disk. Run 'systemctl --user daemon-reload'
> to reload units.

This can be especially problematic in --quiet mode. This patch fixes that by redirecting stderr of the systemctl call used to get the running state of podman to /dev/null.