### PR TITLE
Add prune step to CI

### DIFF
--- a/.github/workflows/wkdev-sdk.yml
+++ b/.github/workflows/wkdev-sdk.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: Prune podman containers/images
+        run: |
+          podman system prune --all --force
+
       - name: Build image
         run: |
           source ./register-sdk-on-host.sh


### PR DESCRIPTION
Clear all the podman images/containers as first step in the CI process.

This assumes, we don't have any concurrent SDK CI builds on the machine that hosts the runner. This holds true, and avoid piling up disk space for dangling images.