### PR TITLE
gst-plugins-rs: Enable fmp4 and disable livesync

### DIFF
--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -138,7 +138,7 @@ RUN export QT_VERSION=$(qmake6 -query QT_VERSION) && \
 RUN gst-inspect-1.0 audiornnoise && \
     gst-inspect-1.0 cea608tott && \
     gst-inspect-1.0 dav1ddec && \
-    gst-inspect-1.0 livesync && \
+    gst-inspect-1.0 isofmp4mux && \
     gst-inspect-1.0 rsrtp
 
 # Remove systemd services that would startup by default, when spawning

--- a/images/wkdev_sdk/jhbuild/webkit-sdk-deps.modules
+++ b/images/wkdev_sdk/jhbuild/webkit-sdk-deps.modules
@@ -133,7 +133,7 @@
             version="1.4.2" />
   </meson>
 
-  <meson id="gst-plugins-rs" mesonargs="-Ddoc=disabled -Dexamples=disabled -Dtests=disabled --auto-features=disabled -Daudiofx=enabled -Dclosedcaption=enabled -Ddav1d=enabled -Dlivesync=enabled -Drtp=enabled">
+  <meson id="gst-plugins-rs" mesonargs="-Ddoc=disabled -Dexamples=disabled -Dtests=disabled --auto-features=disabled -Daudiofx=enabled -Dclosedcaption=enabled -Ddav1d=enabled -Drtp=enabled -Dfmp4=enabled">
     <dependencies>
       <dep package="dav1d"/>
       <dep package="gstreamer"/>


### PR DESCRIPTION
livesync is no longer needed. fmp4 might be used in the MediaRecorder backend.