### PR TITLE
docs: Fix typos and clarify verification step

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ subdirectory for further information the SDK provides but the guide below will c
 Add the following to your shell configuration file (e.g. `~/.bashrc`, `~/.zprofile`, ...)
 to ensure that the `${WKDEV_SDK}` environment variable points to the correct location
 of your `webkit-container-sdk` Git checkout. It also extends the `${PATH}` to make the `wkdev-*` scripts
-provided by this repository accessible without having to specifcy full paths in the shell.
+provided by this repository accessible without having to specify full paths in the shell.
 
 ```sh
 source /absolute/path/to/your/Git/checkout/of/webkit-container-sdk/register-sdk-on-host.sh
 ```
 
-Launch a new shell, or `source` your shell configuration files to verify, `${WKDEV_SDK}`
-now expects as intented - pointing to your `webkit-container-sdk` checkout.
+Launch a new shell, or `source` your shell configuration files, to verify `${WKDEV_SDK}`
+now works as intended -- pointing to your `webkit-container-sdk` checkout.
 
 2. Create a new **wkdev** container for WebKit development
 
@@ -36,7 +36,7 @@ wkdev-create --create-home
 ```
 
 This will create a container named **wkdev** by default or a custom one with `--name`
-and it will create a new home directory for the sdk in `${HOME}/wkdev-home` by default
+and it will create a new home directory for the SDK in `${HOME}/wkdev-home` by default
 or a custom one with `--home`.
 
 Within the container, the `${HOME}` directory is not equal to the host `${HOME}` directory:

--- a/docs/00-Introduction.md
+++ b/docs/00-Introduction.md
@@ -15,7 +15,7 @@ run commands within the **wkdev** container or launch one or more interactive sh
 sessions, in which you can compile WebKit / run tests / etc.
 
 To run CLI applications within a container, requires no effort: it works out of the box.
-Runing graphical applications, that utilize e.g. [Wayland](https://wayland.freedesktop.org)
+Running graphical applications, that utilize e.g. [Wayland](https://wayland.freedesktop.org)
 for screen presentation, need [D-Bus](https://freedesktop.org/wiki/Software/dbus) to communicate
 with other system components, or use [SystemD](https://freedesktop.org/wiki/Software/systemd)
 APIs to query network / power / etc. information, require a substantial amount of configuration
@@ -63,14 +63,14 @@ Let it run, and move on to the **Quickstart guide**.
 Add the following to your shell configuration file (e.g. `~/.bashrc`, `~/.zprofile`, ...)
 to ensure that the `${WKDEV_SDK}` environment variable points to the correct location
 of your `wkdev-sdk` Git checkout. It also extends the `${PATH}` to make the `wkdev-*` scripts
-provided by this repository accessible without having to specifcy full paths in the shell.
+provided by this repository accessible without having to specify full paths in the shell.
 
 ```sh
 source /absolute/path/to/your/Git/checkout/of/wkdev-sdk/register-sdk-on-host.sh
 ```
 
-Launch a new shell, or `source` your shell configuration files to verify, `${WKDEV_SDK}`
-now expects as intented - pointing to your `wkdev-sdk` checkout.
+Launch a new shell, or `source` your shell configuration files, to verify `${WKDEV_SDK}`
+now works as intended -- pointing to your `webkit-container-sdk` checkout.
 
 2. Create a new **wkdev** container for WebKit development
 

--- a/docs/04-Cross-compilation-inside-the-SDK.md
+++ b/docs/04-Cross-compilation-inside-the-SDK.md
@@ -26,6 +26,6 @@ Tools/Scripts/cross-toolchain-helper --cross-target rpi3-32bits-mesa --cross-too
 It is important to unset the `LD_LIBRARY_PATH` otherwise `cross-toolchain-helper` will partly fail,
 but `build-webkit` continues, leading to an inconsistent build environment, that will fail to produce binaries.
 
-sccache is also not supported in that mode, and will interefer with yocto - disable it.
+sccache is also not supported in that mode, and will interfere with yocto -- disable it.
 
 Follow the instructions in Tools/yocto/README.md to flash the image onto your target machine.


### PR DESCRIPTION
Fixed a couple of typos / misspellings, and clarified a paragraph about checking the container had been successfully setup