### PR TITLE
Add support for running containers with foreign architectures

### DIFF
--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -81,8 +81,6 @@ ENV RUSTUP_HOME="/opt/rust" \
     CARGO_HOME="/opt/rust" \
     PATH="/opt/rust/bin:${PATH}"
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-
 RUN rustup default stable && \
     rustup component remove rust-docs && \
     cargo install --root /usr/local --version 0.8.1 --locked sccache && \

--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -81,6 +81,8 @@ ENV RUSTUP_HOME="/opt/rust" \
     CARGO_HOME="/opt/rust" \
     PATH="/opt/rust/bin:${PATH}"
 
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
 RUN rustup default stable && \
     rustup component remove rust-docs && \
     cargo install --root /usr/local --version 0.8.1 --locked sccache && \

--- a/scripts/host-only/wkdev-create
+++ b/scripts/host-only/wkdev-create
@@ -27,6 +27,7 @@ argsparse_use_option attach       "Attach to container as it starts up."
 argsparse_use_option no-pull      "Do not login or pull images."
 argsparse_use_option list-tags    "List available image tags."
 argsparse_use_option =tag:        "Create the container using a specific tag, see-also --list-tags." default:$(get_default_container_tag)
+argsparse_use_option =arch:       "Container architecture."
 
 argsparse_usage_description="$(cat <<EOF
 << Purpose >>
@@ -434,6 +435,12 @@ build_podman_create_arguments() {
         arguments+=("--pull=never")
     else
         arguments+=("--pull=newer")
+    fi
+
+    if argsparse_is_option_set "arch"; then
+        container_arch="${program_options["arch"]}"
+        echo "Overriding container architecture: ${container_arch}"
+        arguments+=("--arch=${container_arch}")
     fi
 
     set +o nounset

--- a/scripts/host-only/wkdev-sdk-bakery
+++ b/scripts/host-only/wkdev-sdk-bakery
@@ -65,7 +65,7 @@ build_image() {
     podman_argument+=("--tag" "$(get_tag_for_build)")
 
     if argsparse_is_option_set "arch"; then
-        container_arch=$(program_options["arch"])
+        container_arch="${program_options["arch"]}"
         echo "Overriding container architecture: ${container_arch}"
         podman_argument+=("--arch=${container_arch}")
     fi

--- a/scripts/host-only/wkdev-sdk-bakery
+++ b/scripts/host-only/wkdev-sdk-bakery
@@ -22,6 +22,7 @@ argsparse_use_option =env:        "Environment variable as string array, e.g. -e
 argsparse_use_option =mode:       "Operation mode: 'build', 'deploy', or 'export'" mandatory
 argsparse_use_option idle-cores:  "Number of CPU cores to leave idle, when building the image" type:uint default:2
 argsparse_use_option =tag:        "Tag to use for created image." default:$(get_default_container_tag)
+argsparse_use_option =arch:       "Container architecture."
 
 argsparse_usage_description="$(cat <<EOF
 << Purpose >>
@@ -62,6 +63,12 @@ build_image() {
 
     local podman_argument=("--jobs" "$(get_number_of_cores_for_build)")
     podman_argument+=("--tag" "$(get_tag_for_build)")
+
+    if argsparse_is_option_set "arch"; then
+        container_arch=$(program_options["arch"])
+        echo "Overriding container architecture: ${container_arch}"
+        podman_argument+=("--arch=${container_arch}")
+    fi
 
     for environment_variable in "${cumulated_values_env[@]}"
     do


### PR DESCRIPTION
This adds a -arch option for building and running the container image.

This was tested with qemu, building an armv7 image for intel. The goal however is to use it for armv7 on arm64.

When building for armv7, rustup was not found. This installs it in the containerfile as a workaround, although I am not sure how this ever worked. It would be nice to provide pre-built armv7 (and perhaps riscv) images.