### PR TITLE
Armv7-build-fix

### DIFF
--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -84,7 +84,8 @@ ENV RUSTUP_HOME="/opt/rust" \
     CARGO_HOME="/opt/rust" \
     PATH="/opt/rust/bin:${PATH}"
 
-RUN rustup default stable && \
+RUN curl --proto '=https' --tlsv1.2 --show-error --silent --fail https://sh.rustup.rs | sh -s -- -y && \
+    rustup default stable && \
     rustup component remove rust-docs && \
     cargo install --root /usr/local --version 0.9.1 --locked sccache && \
     cargo install --root /usr/local cargo-c

--- a/images/wkdev_sdk/required_system_packages/04-devtools.lst
+++ b/images/wkdev_sdk/required_system_packages/04-devtools.lst
@@ -2,7 +2,7 @@
 build-essential cmake ninja-build
 
 # Build tools
-ccache rustup
+ccache
 
 # Debugging / profiling / tracing
 valgrind rr perf-tools-unstable systemd-coredump

--- a/images/wkdev_sdk/required_system_packages/05-armv7-jhbuild.lst
+++ b/images/wkdev_sdk/required_system_packages/05-armv7-jhbuild.lst
@@ -1,0 +1,2 @@
+# Needed for jhbuild on armv7
+libyaml-dev desktop-file-utils


### PR DESCRIPTION
Rustup is not available on armv7, so we install rust manually.

We also add some missing dependencies