### PR TITLE
Add script to install Zed inside the container

### DIFF
--- a/scripts/container-only/wkdev-setup-vscode
+++ b/scripts/container-only/wkdev-setup-vscode
@@ -8,6 +8,14 @@ else
     echo "Please set \${WKDEV_SDK} to point to the root of the wkdev-sdk checkout."
     exit 1
 fi
+if [[ -z ${WKDEV_SDK_HOST} ]]; then
+    echo "Please set \${WKDEV_SDK_HOST} to point to the the wkdev-sdk checkout (from the host perspective). This is used when creating .desktop entries."
+    exit 1
+fi
+if [[ ! -d /host/${HOME} ]]; then
+    echo "Host and container home must have the same path: /host/${HOME}"
+    exit 1
+fi
 source "${WKDEV_SDK}/utilities/prerequisites.sh"
 
 init_application "${0}" "Configures Visual Studio Code." container-only
@@ -17,8 +25,10 @@ verify_executables_exist curl
 argsparse_allow_no_argument true
 argsparse_use_option "=yes" "Assume yes for all prompts."
 argsparse_use_option "no-extensions" "Don't install extensions."
+argsparse_use_option "no-proprietary" "Use VSCodium instead of VSCode."
 
 install_vscode() {
+    CODE_EXEC=code
 
     _log_ ""
     _log_ "Installing Visual Studio Code..."
@@ -40,7 +50,7 @@ install_vscode() {
         exit 1
     fi
 
-    if ! sudo apt install /tmp/code.deb; then
+    if ! sudo apt install -y /tmp/code.deb; then
         _log_ "Failed to install Visual Studio Code."
         rm /tmp/code.deb
         exit 1
@@ -51,7 +61,42 @@ install_vscode() {
     _log_ "Visual Studio Code has been installed."
 }
 
+install_vscodium() {
+    CODE_EXEC=codium
+
+    _log_ ""
+    _log_ "Installing Visual Studio Code (oss)..."
+    _log_ ""
+
+    if which codium > /dev/null; then
+        _log_ "Visual Studio Code (oss) is already installed."
+        return
+    fi
+
+    wget -qO - https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg \
+        | gpg --dearmor \
+        | sudo dd of=/usr/share/keyrings/vscodium-archive-keyring.gpg
+
+    echo 'deb [ signed-by=/usr/share/keyrings/vscodium-archive-keyring.gpg ] https://download.vscodium.com/debs vscodium main' \
+        | sudo tee /etc/apt/sources.list.d/vscodium.list
+
+    if ! sudo apt update; then
+        _log_ "Failed to install Visual Studio Code (oss) repo."
+        exit 1
+    fi
+
+    if ! sudo apt install -y codium; then
+        _log_ "Failed to install Visual Studio Code (oss)."
+        exit 1
+    fi
+
+    _log_ ""
+    _log_ "Visual Studio Code (oss) has been installed."
+}
+
 install_extension() {
+
+    sudo chown "${USER}" "${HOME}/.config"
 
     local extension_name="${1}"
     local description="${2}"
@@ -59,7 +104,7 @@ install_extension() {
     local response
     local installed_extensions
 
-    readarray installed_extensions < <(code --list-extensions)
+    readarray installed_extensions < <($CODE_EXEC --list-extensions)
 
     if [[ "${installed_extensions[*]}" =~ "${extension_name}" ]]; then
         _log_ "VSCode extension already installed: ${extension_name}"
@@ -75,7 +120,7 @@ install_extension() {
         _log_ "Installing VSCode extension: ${extension_name} (${description})..."
     fi
 
-    if ! code --install-extension "${extension_name}" &>/dev/null; then
+    if ! ${CODE_EXEC} --install-extension "${extension_name}" &>/dev/null; then
         _log_ "Failed to install VSCode extension: ${extension_name}"
         exit 1
     fi
@@ -96,15 +141,118 @@ install_extensions() {
     install_extension ms-python.python "Python support" true
 }
 
+# These are VERY helpful for WebKit development, but we won't override existing settings if the user already has them.
+default_settings() {
+    if argsparse_is_option_set "no-proprietary"; then
+        VSCODE_CONFIG_PATH=${HOME}/.config/VSCodium/User/
+    else
+        VSCODE_CONFIG_PATH=${HOME}/.config/Code/User/
+    fi
+    if [[ ! -e "${VSCODE_CONFIG_PATH}/settings.json" ]]; then
+        mkdir -p "${VSCODE_CONFIG_PATH}"
+        tee "${VSCODE_CONFIG_PATH}/settings.json" << HERE
+{
+    "clangd.arguments": [
+        "-header-insertion=never"
+    ],
+    "editor.renderWhitespace": "trailing",
+    "workbench.colorCustomizations": {
+        "editorWhitespace.foreground": "#FF0000",
+        "editorWhitespace.background": "#FF0000"
+    },
+}
+HERE
+        echo "Installed default VSCode settings to ${VSCODE_CONFIG_PATH}."
+    else
+        echo "There was already a VSCode settings.json (${VSCODE_CONFIG_PATH}), skipping."
+    fi
+}
+
+install_xdg() {
+    tee "/host/${HOME}/.local/share/applications/code-wkdev.desktop" << HERE
+[Desktop Entry]
+Name=VSCode WKDev
+Comment=Code Editing. Redefined.
+GenericName=Text Editor
+Exec="${WKDEV_SDK_HOST}/scripts/host-only/wkdev-enter" --exec --no-interactive -- $CODE_EXEC %F
+Icon=vscode-wkdev
+Type=Application
+StartupNotify=false
+StartupWMClass=VSCode
+Categories=TextEditor;Development;IDE;
+MimeType=text/plain;inode/directory;application/x-codium-workspace;
+Keywords=vscode;code;vscode;
+Actions=new-empty-window;
+
+[Desktop Action new-empty-window]
+Name=New Empty Window
+Exec="${WKDEV_SDK_HOST}/scripts/host-only/wkdev-enter" --exec --no-interactive -- $CODE_EXEC --new-window %F
+Icon=vscode-wkdev
+HERE
+    chmod +x "/host/${HOME}/.local/share/applications/code-wkdev.desktop"
+    echo "Installed VSCode host launcher"
+}
+
+install_xdg_oss() {
+    tee "/host/${HOME}/.local/share/applications/codium-wkdev.desktop" << HERE
+[Desktop Entry]
+Name=VSCodium WKDev
+Comment=Code Editing. Redefined.
+GenericName=Text Editor
+Exec="${WKDEV_SDK_HOST}/scripts/host-only/wkdev-enter" --exec --no-interactive -- $CODE_EXEC %F
+Icon=vscodium-wkdev
+Type=Application
+StartupNotify=false
+StartupWMClass=VSCodium
+Categories=TextEditor;Development;IDE;
+MimeType=text/plain;inode/directory;application/x-codium-workspace;
+Keywords=vscodium;codium;vscode;
+Actions=new-empty-window;
+
+[Desktop Action new-empty-window]
+Name=New Empty Window
+Exec="${WKDEV_SDK_HOST}/scripts/host-only/wkdev-enter" --exec --no-interactive -- $CODE_EXEC --new-window %F
+Icon=vscodium-wkdev
+HERE
+    chmod +x "/host/${HOME}/.local/share/applications/codium-wkdev.desktop"
+    echo "Installed VSCodium host launcher"
+}
+
+install_icon() {
+    mkdir -p "/host/${HOME}/.local/share/icons/hicolor/256x256/apps/"
+    cp /usr/share/pixmaps/vscode.png "/host/${HOME}/.local/share/icons/hicolor/256x256/apps/vscode-wkdev.png"
+    echo "Installed VSCode host icon."
+}
+
+install_icon_oss() {
+    mkdir -p "/host/${HOME}/.local/share/icons/hicolor/256x256/apps/"
+    cp /usr/share/pixmaps/vscodium.png "/host/${HOME}/.local/share/icons/hicolor/256x256/apps/vscodium-wkdev.png"
+    echo "Installed VSCodium host icon."
+}
+
 run() {
 
     argsparse_parse_options "${@}"
 
-    install_vscode
+    if argsparse_is_option_set "no-proprietary"; then
+        install_vscodium
+    else
+        install_vscode
+    fi
 
     if ! argsparse_is_option_set "no-extensions"; then
         install_extensions
     fi
+
+    if argsparse_is_option_set "no-proprietary"; then
+        install_xdg_oss
+        install_icon_oss
+    else
+        install_xdg
+        install_icon
+    fi
+
+    default_settings
 }
 
 run "${@}"

--- a/scripts/container-only/wkdev-setup-zed
+++ b/scripts/container-only/wkdev-setup-zed
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Copyright 2024 Igalia S.L.
+# SPDX-License: MIT
+
+if [ -f "${WKDEV_SDK}/.wkdev-sdk-root" ]; then
+    source "${WKDEV_SDK}/utilities/application.sh"
+else
+    echo "Please set \${WKDEV_SDK} to point to the root of the wkdev-sdk checkout."
+    exit 1
+fi
+if [[ -z ${WKDEV_SDK_HOST} ]]; then
+    echo "Please set \${WKDEV_SDK_HOST} to point to the the wkdev-sdk checkout (from the host perspective). This is used when creating .desktop entries."
+    exit 1
+fi
+if [[ ! -d /host/${HOME} ]]; then
+    echo "Host and container home must have the same path: /host/${HOME}"
+    exit 1
+fi
+source "${WKDEV_SDK}/utilities/prerequisites.sh"
+
+init_application "${0}" "Configures Zed." container-only
+
+verify_executables_exist curl
+
+argsparse_allow_no_argument true
+argsparse_use_option "=yes" "Assume yes for all prompts."
+
+install_zed() {
+    CODE_EXEC=code
+
+    _log_ ""
+    _log_ "Installing Zed..."
+    _log_ ""
+
+    if which ${HOME}/.local/bin/zed > /dev/null; then
+        _log_ "Zed is already installed."
+        return
+    fi
+
+    if ! sudo apt install -y mesa-vulkan-drivers vulkan-tools; then
+        _log_ "Could not install mesa vulkan drivers, required for GPU acceleration|"
+	exit 1
+    fi
+
+    local download_url='https://zed.dev/install.sh'
+
+    if ! curl --silent --fail --location "${download_url}" -o /tmp/zed.sh; then
+        _log_ "Failed to download Zed."
+        exit 1
+    fi
+
+    chmod +x /tmp/zed.sh
+    if ! SHELL=/bin/bash /tmp/zed.sh -y; then
+        _log_ "Failed to install Zed."
+        rm /tmp/zed.sh
+        exit 1
+    fi
+
+    rm /tmp/zed.sh
+    _log_ ""
+    _log_ "Zed has been installed."
+}
+
+
+install_xdg() {
+    tee "/host/${HOME}/.local/share/applications/zed-wkdev.desktop" << HERE
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Zed
+GenericName=Text Editor
+Comment=A high-performance, multiplayer code editor.
+StartupNotify=true
+Exec="${WKDEV_SDK_HOST}/scripts/host-only/wkdev-enter" --exec --no-interactive -- "${HOME}/.local/bin/zed" %u
+Icon=zed-wkdev
+Categories=Utility;TextEditor;Development;IDE;
+Keywords=zed;
+MimeType=text/plain;application/x-zerosize;x-scheme-handler/zed;
+Actions=NewWorkspace;
+
+[Desktop Action NewWorkspace]
+Exec="${WKDEV_SDK_HOST}/scripts/host-only/wkdev-enter" --exec --no-interactive -- "${HOME}/.local/bin/zed" --new %U
+Name=Open a new workspace
+
+HERE
+    chmod +x "/host/${HOME}/.local/share/applications/zed-wkdev.desktop"
+    echo "Installed Zed host launcher"
+}
+
+install_icon() {
+    mkdir -p "/host/${HOME}/.local/share/icons/hicolor/256x256/apps/"
+    cp ~/.local/zed.app/share/icons/hicolor/1024x1024/apps/zed.png "/host/${HOME}/.local/share/icons/hicolor/256x256/apps/zed-wkdev.png"
+    echo "Installed Zed host icon."
+}
+
+# These are VERY helpful for WebKit development, but we won't override existing settings if the user already has them.
+default_settings() {
+    ZED_CONFIG_PATH="${HOME}/.config/zed/"
+    if [[ ! -e "${ZED_CONFIG_PATH}/settings.json" ]]; then
+        sudo chown "${USER}" "${HOME}/.config/"
+        mkdir -p "${ZED_CONFIG_PATH}"
+        tee "${ZED_CONFIG_PATH}/settings.json" << HERE
+{
+    "ui_font_size": 16,
+    "buffer_font_size": 16,
+    "theme": {
+    "mode": "system",
+    "light": "One Light",
+    "dark": "One Dark"
+    },
+    "use_system_path_prompts": false, // Use in-container paths instead of host paths
+    "lsp": {
+      "clangd": {
+        "binary": {
+          "arguments": ["--header-insertion=never"]
+        }
+      }
+    },
+}
+
+HERE
+        echo "Installed default Zed settings to ${ZED_CONFIG_PATH} as user ${USER}."
+    else
+        echo "There was already a Zed settings.json (${ZED_CONFIG_PATH}), skipping."
+    fi
+}
+
+run() {
+
+    argsparse_parse_options "${@}"
+
+    install_zed
+    install_xdg
+    install_icon
+    default_settings
+}
+
+run "${@}"

--- a/scripts/host-only/wkdev-create
+++ b/scripts/host-only/wkdev-create
@@ -431,6 +431,9 @@ build_podman_create_arguments() {
     # Always set XDG_RUNTIME_DIR to the same value.
     arguments+=("--env" "XDG_RUNTIME_DIR=/run/user/${host_user_id}")
 
+    # This is needed for some scripts like wkdev-setup-vscode
+    arguments+=("--env" "WKDEV_SDK_HOST=${WKDEV_SDK}")
+
     if argsparse_is_option_set "no-pull"; then
         arguments+=("--pull=never")
     else

--- a/scripts/host-only/wkdev-enter
+++ b/scripts/host-only/wkdev-enter
@@ -169,6 +169,9 @@ run() {
     # Ensure WKDEV_SDK is set. It is done here and not creation to support older containers.
     podman_exec_arguments+=("--env" "WKDEV_SDK=/wkdev-sdk")
 
+    # This is needed for some scripts like wkdev-setup-vscode
+    podman_exec_arguments+=("--env" "WKDEV_SDK_HOST=${WKDEV_SDK}")
+
     # Choose root or regular user.
     if argsparse_is_option_set "root"; then
         podman_exec_arguments+=("--user" "0:0")


### PR DESCRIPTION
In the interest of supporting more editors, this patch adds a script to install Zed. It would be nice for all of the most common editors to be supported, but certainly the Free ones should be included.

In general, I would love to know the stance of this project on including features like this. I don't use or have a licence for Sublime or CLion, although I would vote that this repository should support using them if somebody wants to submit a patch. That is, I think we should support the set of things that anybody might use, rather than the subset that everybody uses. For example, I am not a Vim/Emacs user, but I would see value personally if someone shared a good default configuration that worked in the container with clangd.

At the same time, I understand this might cause some dramatic scope creep / maintenance overhead. 

In particular, for this PR, Zed requires workarounds in the container to get GPU access. For that reason, regardless of the result of the discussion above, I think this install script can be included without setting the precedent that every editor can be included.

This should land after the VSCodium PR. I didn't bother to duplicate that PR since I assumed any feedback on that PR would immediately apply here.