### PR TITLE
jhbuild: Bump to openh264 2.6.0

### DIFF
--- a/images/wkdev_sdk/jhbuild/webkit-sdk-deps.modules
+++ b/images/wkdev_sdk/jhbuild/webkit-sdk-deps.modules
@@ -101,7 +101,7 @@
     <branch repo="github.com"
             checkoutdir="openh264"
             module="cisco/openh264.git"
-            tag="v2.4.1" >
+            tag="v2.6.0" >
     </branch>
   </meson>
 


### PR DESCRIPTION
Including a critical security fix (https://github.com/cisco/openh264/security/advisories/GHSA-m99q-5j7x-7m9x)