### PR TITLE
Fix issues when running inside a LXC container.

### DIFF
--- a/scripts/host-only/wkdev-create
+++ b/scripts/host-only/wkdev-create
@@ -406,12 +406,12 @@ build_podman_create_arguments() {
     arguments+=("--mount" "type=bind,source=/etc/resolv.conf,destination=/etc/resolv.conf,ro")
     arguments+=("--mount" "type=bind,source=/etc/machine-id,destination=/etc/machine-id,ro,rslave")
 
-    # Mount /dev/pts in container (pseudo-terminal support).
-    arguments+=("--mount" "type=devpts,destination=/dev/pts")
+    # Mount /dev/pts in container (pseudo-terminal support) only if not running inside a LXC container.
+    [ "$(systemd-detect-virt)" != "lxc" ] && arguments+=("--mount" "type=devpts,destination=/dev/pts")
 
     # Mount /dev and /run/udev for devices like gamepads
     arguments+=("-v" "/dev/:/dev:rslave")
-    arguments+=("-v" "/run/udev:/run/udev")
+    [ -d "/run/udev" ] && arguments+=("-v" "/run/udev:/run/udev")
 
     # Mount a tmpfs.
     arguments+=("--tmpfs" "/tmp")


### PR DESCRIPTION
* When running inside LXC do not manually mount `/dev/pts` and let Podman figure this out. Otherwise this causes a fatal error when starting the container because it can't access `/dev/pts/$N`. Related issue: https://github.com/89luca89/distrobox/issues/688

* Also do not try to bind-mount `/run/udev` if is not available.