### PR TITLE
Print errors from podman start

### DIFF
--- a/scripts/host-only/wkdev-create
+++ b/scripts/host-only/wkdev-create
@@ -420,13 +420,13 @@ build_podman_create_arguments() {
     arguments+=("--mount" "type=bind,source=${XDG_RUNTIME_DIR},destination=/host/run,bind-propagation=rslave")
 
     # Disable SELinux isolation.
-    arguments+=("--security-opt label=disable")
+    arguments+=("--security-opt" "label=disable")
 
     # Allow for unprivileged user namespaces (bwrap) to work.
-    arguments+=("--security-opt unmask=ALL")
+    arguments+=("--security-opt" "unmask=ALL")
 
     # Required for rr to work.
-    arguments+=("--security-opt seccomp=unconfined")
+    arguments+=("--security-opt" "seccomp=unconfined")
 
     # Always set XDG_RUNTIME_DIR to the same value.
     arguments+=("--env" "XDG_RUNTIME_DIR=/run/user/${host_user_id}")
@@ -705,21 +705,26 @@ run() {
     _log_ "-> Creating container '${container_name}'..."
     if argsparse_is_option_set "verbose"; then
         _log_ ""
-        _log_ "     $ podman ${podman_arguments[@]} create ${podman_create_arguments[@]}"
+        _log_ "     $ $(shjoin podman "${podman_arguments[@]}" create "${podman_create_arguments[@]}")"
     fi
 
-    container_id=$(run_podman ${podman_arguments[@]} create ${podman_create_arguments[@]})
+    container_id=$(run_podman "${podman_arguments[@]}" create "${podman_create_arguments[@]}")
     [ -z "${container_id}" ] && _abort_ "Container creation failed - please check the logs and report any issue"
 
     _log_ ""
     _log_ "-> Starting container '${container_name}'..."
-
+    local args=()
     if argsparse_is_option_set "attach"; then
-        run_podman_silent_unless_verbose start --attach "${container_id}"
+        args=(start --attach "${container_id}")
     else
         _log_ "   NOTE: Use \`podman logs -f ${container_name}\` to follow the initialization."
-        run_podman_silent start "${container_id}"
+        args=(start "${container_id}")
     fi
+    if argsparse_is_option_set "verbose"; then
+        _log_ ""
+        _log_ "     $ $(shjoin podman "${args[@]}")"
+    fi
+    run_podman_silent_unless_verbose_or_abort "${args[@]}"
 
     _log_ ""
     _log_ "-> Finished creation of container '${container_name}'!"

--- a/scripts/host-only/wkdev-enter
+++ b/scripts/host-only/wkdev-enter
@@ -91,7 +91,9 @@ ensure_container_is_running() {
         _log_ "";
         _log_ "-> Container '${container_name}' is not yet running. Starting it before attempting to enter...";
         host_setup_prerun_tasks
-        run_podman_silent start "${container_name}"
+        # There is no flag to prevent `podman start` from writing the id of the
+        # container to stdout, so we just connect stdout to /dev/null.
+        run_podman_silent_unless_verbose_or_abort start "${container_name}" >/dev/null
     }
 }
 

--- a/utilities/podman.sh
+++ b/utilities/podman.sh
@@ -20,6 +20,7 @@ verify_podman_is_acceptable "${podman_executable}"
 run_podman() { run_command "${podman_executable}" "${@}"; }
 run_podman_silent() { run_command_silent "${podman_executable}" "${@}"; }
 run_podman_silent_unless_verbose() { run_command_silent_unless_verbose "${podman_executable}" "${@}"; }
+run_podman_silent_unless_verbose_or_abort() { run_command_silent_unless_verbose_or_abort "${podman_executable}" "${@}"; }
 
 run_podman_in_background_and_log_to_file() {
 


### PR DESCRIPTION
podman start gives reasonably good error messages, but they're currently being lost as the command is run silently.

This patch adds a new function to run commands silently but storing their stderr output to report it in case of an error.

As a drive-by fix, this patch also fixes some quoting issues in wkdev-create.

Fixes https://github.com/Igalia/webkit-container-sdk/issues/35