### PR TITLE
Add x264 to system dependencies

### DIFF
--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -77,7 +77,7 @@ RUN sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.s
     ${APT_AUTOREMOVE}
 
 # GStreamer 1.26.x requires at least Meson 1.4. Install the latest version.
-RUN pip install meson==1.7.0 --break-system-packages
+RUN pip install meson==1.8.0 --break-system-packages
 
 # Ensure a strong TLS connection is always used when downloading sensitive files.
 ARG CURL_DOWNLOAD="curl --proto =https --tlsv1.2 --show-error --silent --fail"

--- a/images/wkdev_sdk/jhbuild/webkit-sdk-deps.modules
+++ b/images/wkdev_sdk/jhbuild/webkit-sdk-deps.modules
@@ -105,7 +105,7 @@
     </branch>
   </meson>
 
-  <meson id="gstreamer" mesonargs="-Dlibnice=enabled -Dpython=enabled -Dintrospection=enabled -Dgst-plugins-bad:microdns=disabled -Dgst-plugins-bad:avtp=disabled -Dgst-examples=disabled -Dexamples=disabled -Dtests=disabled -Ddoc=disabled -Dgtk_doc=disabled -Dwebrtc=enabled">
+  <meson id="gstreamer" mesonargs="-Dlibnice=enabled -Dpython=enabled -Dintrospection=enabled -Dgst-plugins-bad:microdns=disabled -Dgst-plugins-bad:avtp=disabled -Dgst-examples=disabled -Dexamples=disabled -Dtests=disabled -Ddoc=disabled -Dgtk_doc=disabled -Dwebrtc=enabled -Dgst-plugins-ugly:gpl=enabled -Dgst-plugins-bad:gpl=enabled -Dgpl=enabled">
     <branch repo="gstreamer.freedesktop.org"
             checkoutdir="gstreamer"
             module="gstreamer.git"

--- a/images/wkdev_sdk/required_system_packages/01-base.lst
+++ b/images/wkdev_sdk/required_system_packages/01-base.lst
@@ -12,3 +12,6 @@ wireplumber
 
 # General utilities
 apt-file aptly atop at-spi2-core emacs git htop iotop iputils-ping kmod less libportal-dev libportal-gtk4-dev libxcb-cursor-dev locate man-db nano openssh-client strace sudo zip unzip vim-gtk3 wget
+
+# Multimedia
+libx264-dev


### PR DESCRIPTION
Otherwise openh264 is selected for GStreamer layout tests and that encoder is not as functional as x264enc which is also currently selected by default in the legacy SDK.