### PR TITLE
Use intel worker for deploy phase

### DIFF
--- a/.github/workflows/wkdev-sdk.yml
+++ b/.github/workflows/wkdev-sdk.yml
@@ -95,7 +95,7 @@ jobs:
           rm -rf ${HOME}/${CONTAINER}-home
 
   deploy:
-    runs-on: arm-bothost-2
+    runs-on: [self-hosted, x64]
     needs: [build_amd64, build_arm64]
     if: github.ref_name == 'main' || startsWith(github.ref_name, 'tag/')
     steps:


### PR DESCRIPTION
The arm64 machine isn't working because of some disk issues, let's use the working intel machine for now.