### PR TITLE
Delete existing images before loading

### DIFF
--- a/.github/workflows/wkdev-sdk.yml
+++ b/.github/workflows/wkdev-sdk.yml
@@ -122,6 +122,10 @@ jobs:
 
       - name: Deploy image
         run: |
+          podman rmi ghcr.io/${GITHUB_REPOSITORY_OWNER}/wkdev-sdk:latest | true
+          podman manifest rm ghcr.io/${GITHUB_REPOSITORY_OWNER}/wkdev-sdk:latest | true
+          podman rmi ghcr.io/${GITHUB_REPOSITORY_OWNER}/wkdev-sdk:latest_arm64 | true
+          podman rmi ghcr.io/${GITHUB_REPOSITORY_OWNER}/wkdev-sdk:latest_amd64 | true
           podman load < ./wkdev-sdk-amd64.tar
           podman load < ./wkdev-sdk-arm64.tar
           podman image list

--- a/scripts/host-only/wkdev-sdk-bakery
+++ b/scripts/host-only/wkdev-sdk-bakery
@@ -100,8 +100,6 @@ deploy_image() {
         image_qualified="$(get_tag_for_build)"
         echo "Building multiarch image for ${image_qualified}"
         input_tags="$(podman image list "${image}" --format "{{.Tag}}" | grep "${target_tag}_")"
-        run_podman_silent_unless_verbose rmi --ignore "${image_qualified}" || true
-        run_podman_silent_unless_verbose manifest rm "${image_qualified}" || true
         echo "Creating manifest for ${image_qualified}"
         run_podman_silent_unless_verbose manifest create "${image_qualified}" || _abort_ "Creating manifest failed"
         for input_tag in "${input_tags[@]}"


### PR DESCRIPTION
Podman deletes the underlying linked images when we delete the latest tag. We end up getting:

Load/replace latest_arm64

Load/replace latest_amd64

Delete latest (deletes latest_arm64 and latest_amd64)

Create latest

Add latest_amd64 (fails)

Instead, we should delete the existing images and the latest manifest first.