### PR TITLE
Modify our .gdbinit default file, to handle SIGUSR1.

### DIFF
--- a/images/wkdev_sdk/user_home_directory_defaults/dot-gdbinit
+++ b/images/wkdev_sdk/user_home_directory_defaults/dot-gdbinit
@@ -6,3 +6,4 @@ set print array-indexes on
 set python print-stack full
 set debuginfod enabled on
 set sysroot /
+handle SIGUSR1 nostop noprint


### PR DESCRIPTION
After attaching to WPEWebProcess, gdb would halt all the time at SIGUSR1. Make sure to set the SIGUSR1 handler to 'nostop' so it doesn't halt in gdb everytime it fires (JSC uses this for GC internally).