### PR TITLE
Use podman manifest push instead of podman push for multiarch images

### DIFF
--- a/scripts/host-only/wkdev-sdk-bakery
+++ b/scripts/host-only/wkdev-sdk-bakery
@@ -108,9 +108,11 @@ deploy_image() {
             echo "Adding ${image}:${input_tag} to ${image_qualified}"
             run_podman_silent_unless_verbose manifest add "${image_qualified}" "containers-storage:${image}:${input_tag}" || _abort_ "Adding to manifest failed"
         done
+        run_podman_silent_unless_verbose manifest push --all "$(get_tag_for_build)" "docker://$(get_tag_for_build)" || _abort_ "Pushing to registry failed"
+    else
+        run_podman_silent_unless_verbose push "$(get_tag_for_build)" || _abort_ "Pushing to registry failed"
     fi
 
-    run_podman_silent_unless_verbose push "$(get_tag_for_build)" || _abort_ "Pushing to registry failed"
     popd &>/dev/null
 }
 


### PR DESCRIPTION
This is required for push to push all images, instead of just the one for the current architecture.