### PR TITLE
wkdev-create should only check if image exists when no-pull is set

### DIFF
--- a/scripts/host-only/wkdev-create
+++ b/scripts/host-only/wkdev-create
@@ -442,15 +442,19 @@ build_podman_create_arguments() {
         echo "Overriding container architecture: ${container_arch}"
         arguments+=("--arch=${container_arch}")
 
-        if ! podman image exists "$(get_sdk_qualified_name):${container_tag}"; then
-            echo "Image $(get_sdk_qualified_name):${container_tag} does not exist, trying arch-specific version."
-            container_tag="${container_tag}_${container_arch}"
+        if argsparse_is_option_set "no-pull"; then
+            if ! podman image exists "$(get_sdk_qualified_name):${container_tag}"; then
+                echo "Image $(get_sdk_qualified_name):${container_tag} does not exist, trying arch-specific version."
+                container_tag="${container_tag}_${container_arch}"
+            fi
         fi
     fi
 
-    if ! podman image exists "$(get_sdk_qualified_name):${container_tag}"; then
-        echo "Image $(get_sdk_qualified_name):${container_tag} does not exist."
-        exit 1
+    if argsparse_is_option_set "no-pull"; then
+        if ! podman image exists "$(get_sdk_qualified_name):${container_tag}"; then
+            echo "Image $(get_sdk_qualified_name):${container_tag} does not exist."
+            exit 1
+        fi
     fi
     echo "Using image $(get_sdk_qualified_name):${container_tag}."
 


### PR DESCRIPTION
This is useful to ensure that the testing phase in CI does not test the wrong image, while still allowing people to pull automatically at their desk.