### PR TITLE
devtools: Add libappstream-dev

### DIFF
--- a/images/wkdev_sdk/required_system_packages/04-devtools.lst
+++ b/images/wkdev_sdk/required_system_packages/04-devtools.lst
@@ -21,6 +21,7 @@ podman
 
 # For libadwaita
 libyaml-dev
+libappstream-dev
 
 # post-install for Epiphany
 desktop-file-utils


### PR DESCRIPTION
Required for Adwaita.

Fixes #151