### PR TITLE
devtools: Add monado-service

### DIFF
--- a/images/wkdev_sdk/required_system_packages/04-devtools.lst
+++ b/images/wkdev_sdk/required_system_packages/04-devtools.lst
@@ -25,3 +25,6 @@ libappstream-dev
 
 # post-install for Epiphany
 desktop-file-utils
+
+# For OpenXR tests
+monado-service


### PR DESCRIPTION
This is required to run WebKit tests (and other applications) needing an OpenXR runtime.

Fixes #154