### PR TITLE
devtools: Add libopenxr1-monado

### DIFF
--- a/images/wkdev_sdk/required_system_packages/04-devtools.lst
+++ b/images/wkdev_sdk/required_system_packages/04-devtools.lst
@@ -27,4 +27,5 @@ libappstream-dev
 desktop-file-utils
 
 # For OpenXR tests
+libopenxr1-monado
 monado-service


### PR DESCRIPTION
Added libopenxr1-monado, the Monado implementation of the OpenXR API, as without this monado-service is not enough to run OpenXR WebKit tests.

Fixes #154