### PR TITLE
Filter 'create' event to only trigger for tag/ branches

### DIFF
--- a/.github/workflows/wkdev-sdk.yml
+++ b/.github/workflows/wkdev-sdk.yml
@@ -12,6 +12,9 @@ defaults:
 jobs:
   build_amd64:
     runs-on: [self-hosted, x64]
+    if: |
+      github.event_name != 'create' ||
+      startsWith(github.ref_name, 'tag/')
     steps:
       - name: Set tag name
         run: |
@@ -60,6 +63,9 @@ jobs:
 
   build_arm64:
     runs-on: arm-bothost-2
+    if: |
+      github.event_name != 'create' ||
+      startsWith(github.ref_name, 'tag/')
     steps:
       - name: Set tag name
         run: |
@@ -108,6 +114,9 @@ jobs:
 
   build_armv7:
     runs-on: arm-bothost-4
+    if: |
+      github.event_name != 'create' ||
+      startsWith(github.ref_name, 'tag/')
     steps:
       - name: Set tag name
         run: |
@@ -157,7 +166,9 @@ jobs:
   deploy:
     runs-on: [self-hosted, x64]
     needs: [build_amd64, build_armv7, build_arm64]
-    if: github.ref_name == 'main' || startsWith(github.ref_name, 'tag/')
+    if: |
+      (github.event_name != 'create' || startsWith(github.ref_name, 'tag/')) &&
+      (github.ref_name == 'main' || startsWith(github.ref_name, 'tag/'))
     steps:
       - name: Set tag name
         run: |


### PR DESCRIPTION
The 'create' workflow trigger was firing for all branch creations, including PR branches, causing unnecessary workflow runs. GitHub Actions does not support filtering the 'create' event at the trigger level.

Added job-level conditionals to all 4 jobs to skip execution when the event is 'create' and the branch name does not start with 'tag/'. This preserves the auto-trigger functionality for tag branches (e.g., tag/23.04) while preventing workflows from running on regular branch creation.