### PR TITLE
Include cross toolchain and deps for JSConly on armhf

### DIFF
--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -59,9 +59,21 @@ RUN dpkg-reconfigure locales
 # Install all dependencies for WebKit/GStreamer/etc in one pass.
 WORKDIR /var/tmp/wkdev-packages
 COPY /required_system_packages/*.lst .
+
+# We unconditionally install the GCC-based cross toolchain for armhf.
+COPY /cross .
+
 RUN sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources && \
+    if [ "$(uname -m)" = "x86_64" ]; then \
+        sed -r 's@(archive|security).ubuntu.com/ubuntu@ports.ubuntu.com/ubuntu-ports@g' </etc/apt/sources.list.d/ubuntu.sources >/etc/apt/sources.list.d/ubuntu-armhf.sources; \
+        sed -i -r 's/^(Components:.*)/\1\nArchitectures: amd64/' /etc/apt/sources.list.d/ubuntu.sources; \
+        sed -i -r 's/^(Components:.*)/\1\nArchitectures: armhf/' /etc/apt/sources.list.d/ubuntu-armhf.sources; \
+    fi && \
+    dpkg --add-architecture armhf && \
     ${APT_UPDATE} && \
-    for list in *.lst; do \
+    export LST_FILES=*.lst && \
+    if [ "$(uname -m)" = "x86_64" -o "$(uname -m)" = "aarch64" ]; then export LST_FILES="$LST_FILES $(echo armhf/*.lst)"; fi; \
+    for list in $LST_FILES; do \
         ${APT_INSTALL} $(sed -e "s/.*#.*//; /^$/d" "${list}" | tr '\n' ' '); \
     done; \
     ${APT_BUILDDEP} gst-libav1.0 gst-plugins-bad1.0 gst-plugins-base1.0 \
@@ -168,6 +180,9 @@ RUN gst-inspect-1.0 audiornnoise && \
 # Check locally installed libraries.
 RUN pkg-config --modversion rice-io && \
     pkg-config --modversion rice-proto
+
+# Place the toolchainfiles in a discoverable location.
+RUN mkdir -p /usr/share/wkdev-sdk/cross/armhf && cp -r /var/tmp/wkdev-packages/armhf/*.cmake /usr/share/wkdev-sdk/cross/armhf/
 
 # Remove systemd services that would startup by default, when spawning
 # systemd as PID 1 within the container (usually, we don't spawn systemd

--- a/images/wkdev_sdk/cross/armhf/01-toolchain.lst
+++ b/images/wkdev_sdk/cross/armhf/01-toolchain.lst
@@ -1,0 +1,2 @@
+gcc-arm-linux-gnueabihf
+g++-arm-linux-gnueabihf

--- a/images/wkdev_sdk/cross/armhf/02-jsconly-dependencies.lst
+++ b/images/wkdev_sdk/cross/armhf/02-jsconly-dependencies.lst
@@ -1,0 +1,1 @@
+libicu-dev:armhf

--- a/images/wkdev_sdk/cross/armhf/toolchainfile-clang.cmake
+++ b/images/wkdev_sdk/cross/armhf/toolchainfile-clang.cmake
@@ -1,0 +1,13 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_CXX_COMPILER clang++)
+set(CMAKE_C_COMPILER_TARGET arm-linux-gnueabihf)
+set(CMAKE_CXX_COMPILER_TARGET arm-linux-gnueabihf)
+set(CMAKE_LINKER_TYPE LLD)
+
+set(CMAKE_FIND_ROOT_PATH /usr/arm-linux-gnueabihf;/usr/lib/arm-linux-gnueabihf;)
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)

--- a/images/wkdev_sdk/cross/armhf/toolchainfile-gcc.cmake
+++ b/images/wkdev_sdk/cross/armhf/toolchainfile-gcc.cmake
@@ -1,0 +1,10 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+set(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)
+set(CMAKE_CXX_COMPILER arm-linux-gnueabihf-g++)
+
+set(CMAKE_FIND_ROOT_PATH /usr/arm-linux-gnueabihf;/usr/lib/arm-linux-gnueabihf;)
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)


### PR DESCRIPTION
- Pull in the cross GCC provided by Ubuntu for armhf (the included clang is a cross compiler anyway).
- Install the single armhf dependency for JSCOnly.
- Provide cmake toolchain files for cross-building.

With this in place, we can now cross-build JSCOnly for armhf out of the box, using:

./Tools/Scripts/build-jsc --jsc-only '--cmakeargs=-DCMAKE_TOOLCHAIN_FILE=/usr/share/wkdev-sdk/cross/armhf/toolchainfile-gcc.cmake'

(s/gcc/clang/ for building with clang).