### PR TITLE
Specify the default OpenXR runtime

### DIFF
--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -168,6 +168,10 @@ RUN export QT_VERSION=$(qmake6 -query QT_VERSION) && \
       ln -s ${directory} ${directory}/${QT_VERSION}  >/dev/null 2>&1 || true; \
     done
 
+# Specify the default OpenXR runtime
+RUN mkdir -p /etc/xdg/openxr/1 && \
+    ln -s /jhbuild/install/share/openxr/1/openxr_monado.json /etc/xdg/openxr/1/active_runtime.json
+
 # Check GStreamer plugins are installed.
 RUN gst-inspect-1.0 audiornnoise && \
     gst-inspect-1.0 cea608tott && \


### PR DESCRIPTION
Before this change, one had to specify the Monado runtime by using the
XR_RUNTIME_JSON environment variable.

Monado document recommends to create a symlink in a systemwide xdg config path.
<https://monado.freedesktop.org/getting-started.html>
And, Monado has a build option XRT_OPENXR_INSTALL_ACTIVE_RUNTIME to do it.
However, it doesn't work with jhbuild because jhbuild prevents installing files
outside of prefix.

> I: Moving temporary DESTDIR '/jhbuild/install/_jhbuild/root-monado' into build prefix
> W: Files remaining in buildroot '/jhbuild/install/_jhbuild/root-monado-broken'; module may have installed files outside of prefix.

Create a symlink in the systemwide xdg config path.
