### PR TITLE
chown the directories in the image and skip chown of the first entry

### DIFF
--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -190,5 +190,8 @@ RUN mkdir -p /usr/share/wkdev-sdk/cross/armhf && cp -r /var/tmp/wkdev-packages/a
 # when deploying the wkdev-sdk image as bot).
 RUN find /etc/systemd/ -type l -name '*.service' -print -exec rm {} \;
 
+# Change the owner to UID 1000 as a fast path
+RUN chown --recursive 1000:1000 ${RUSTUP_HOME} /jhbuild
+
 # Switch back to interactive prompt, when using apt.
 ENV DEBIAN_FRONTEND dialog

--- a/scripts/container-only/.wkdev-init
+++ b/scripts/container-only/.wkdev-init
@@ -199,8 +199,11 @@ try_setup_permissions_jhbuild_directory() {
 
     task_step "Setup jhbuild '${jhbuild_directory}' directory permissions..."
 
-    chown --recursive "${container_user_name}:${container_group_name}" "${jhbuild_directory}" &>/dev/null
-
+    if sudo -u "${container_user_name}" test -w "${jhbuild_directory}"; then
+        task_step "Already writable, skipping."
+    else
+        chown --recursive "${container_user_name}:${container_group_name}" "${jhbuild_directory}" &>/dev/null
+    fi
 }
 
 try_setup_permissions_rust_directory() {
@@ -209,7 +212,11 @@ try_setup_permissions_rust_directory() {
 
     task_step "Setup rust '${rust_directory}' directory permissions..."
 
-    chown --recursive "${container_user_name}:${container_group_name}" "${rust_directory}" &>/dev/null
+    if sudo -u "${container_user_name}" test -w "${rust_directory}"; then
+        task_step "Already writable, skipping."
+    else
+        chown --recursive "${container_user_name}:${container_group_name}" "${rust_directory}" &>/dev/null
+    fi
 }
 
 try_firstrun_script() {


### PR DESCRIPTION
~~~
Previously, it did chown /opt/rust and /jhbuild directories to the user's UID
at the first time of wkdev-enter. It took a while to finish.

In the most cases, the user's UID is 1000. Added a fast path by assuming the
UID is 1000. Execute chown for the directories in Containerfile. And, skip the
chown at the first entry if the directories are already writable.
~~~
