### PR TITLE
apt-get update is randomly failing to acquire a lock

### DIFF
--- a/.github/workflows/wkdev-sdk.yml
+++ b/.github/workflows/wkdev-sdk.yml
@@ -25,7 +25,7 @@ jobs:
           echo "REPO=ghcr.io/$(echo ${GITHUB_REPOSITORY_OWNER} | tr '[:upper:]' '[:lower:]')/wkdev-sdk" >> "${GITHUB_ENV}"
 
       - name: Install podman
-        run: sudo apt-get update && sudo apt-get -y install podman fuse-overlayfs
+        run: sudo apt-get -o DPkg::lock::Timeout=600 update && sudo apt-get -y install podman fuse-overlayfs
 
       - name: Prune old containers/images
         run: |
@@ -97,7 +97,7 @@ jobs:
           echo "REPO=ghcr.io/$(echo ${GITHUB_REPOSITORY_OWNER} | tr '[:upper:]' '[:lower:]')/wkdev-sdk" >> "${GITHUB_ENV}"
 
       - name: Install podman
-        run: sudo apt-get update && sudo apt-get -y install podman fuse-overlayfs
+        run: sudo apt-get -o DPkg::lock::Timeout=600 update && sudo apt-get -y install podman fuse-overlayfs
 
       - name: Prune old containers/images
         run: |
@@ -169,7 +169,7 @@ jobs:
           echo "REPO=ghcr.io/$(echo ${GITHUB_REPOSITORY_OWNER} | tr '[:upper:]' '[:lower:]')/wkdev-sdk" >> "${GITHUB_ENV}"
 
       - name: Install podman
-        run: sudo apt-get update && sudo apt-get -y install podman fuse-overlayfs
+        run: sudo apt-get -o DPkg::lock::Timeout=600 update && sudo apt-get -y install podman fuse-overlayfs
 
       - name: Prune old containers/images
         run: |
@@ -242,7 +242,7 @@ jobs:
           echo "REPO=ghcr.io/$(echo ${GITHUB_REPOSITORY_OWNER} | tr '[:upper:]' '[:lower:]')/wkdev-sdk" >> "${GITHUB_ENV}"
 
       - name: Install podman
-        run: sudo apt-get update && sudo apt-get -y install podman fuse-overlayfs
+        run: sudo apt-get -o DPkg::lock::Timeout=600 update && sudo apt-get -y install podman fuse-overlayfs
 
       - name: Prune old containers/images
         run: |


### PR DESCRIPTION
GitHub actions were reporting an error:

> E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 3200398 (unattended-upgr)
> E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?

Added `-o DPkg::lock::Timeout=600` option to apt-get update.
