### PR TITLE
Add python virtualenv to system dependencies

### DIFF
--- a/images/wkdev_sdk/required_system_packages/01-base.lst
+++ b/images/wkdev_sdk/required_system_packages/01-base.lst
@@ -11,7 +11,7 @@ libnvidia-egl-wayland1
 wireplumber
 
 # General utilities
-apt-file aptly atop at-spi2-core bind9-dnsutils emacs git htop iotop iputils-ping kmod less libportal-dev libportal-gtk4-dev libxcb-cursor-dev locate man-db nano openssh-client strace sudo zip unzip vim-gtk3 wget
+apt-file aptly atop at-spi2-core bind9-dnsutils emacs git htop iotop iputils-ping kmod less libportal-dev libportal-gtk4-dev libxcb-cursor-dev locate man-db nano openssh-client python3-virtualenv strace sudo zip unzip vim-gtk3 wget
 
 # Multimedia
 libx264-dev


### PR DESCRIPTION
This allows installing python libraries on an isolated environment from the system, which is helpful for multiple things, among those deploying the buildot workers with a specific version of buildbot.