### PR TITLE
Install symlinks from bare programs to python3 versions

### DIFF
--- a/images/wkdev_sdk/required_system_packages/01-base.lst
+++ b/images/wkdev_sdk/required_system_packages/01-base.lst
@@ -13,6 +13,9 @@ wireplumber
 # General utilities
 apt-file aptly atop at-spi2-core bind9-dnsutils emacs git htop iotop iputils-ping kmod less libportal-dev libportal-gtk4-dev libxcb-cursor-dev locate man-db nano openssh-client python3-virtualenv strace sudo zip unzip vim-gtk3 wget
 
+# Make python a symbolic link to python3 (and related binaries)
+python-is-python3
+
 # Multimedia
 libx264-dev
 libx265-dev


### PR DESCRIPTION
Add the python-is-python3 package to the list of installed ones. This includes unversioned symlinks point to Python 3.x binaries: `python` will be a symbolic link to `python3`, `pydoc` to `pydoc3` and so on, for the sake of convenience.