### PR TITLE
monado: Bump to the latest v25.1.0

### DIFF
--- a/images/wkdev_sdk/jhbuild/webkit-sdk-deps.modules
+++ b/images/wkdev_sdk/jhbuild/webkit-sdk-deps.modules
@@ -167,7 +167,7 @@
   <cmake id="monado">
     <branch repo="freedesktop.org"
 	    checkoutdir="monado"
-	    module="monado/monado.git" tag="v25.0.0"/>
+	    module="monado/monado.git" tag="v25.1.0"/>
   </cmake>
 
   <!-- Everything in this section is just for Epiphany. -->


### PR DESCRIPTION
monado: Bump to the latest v25.1.0

<https://gitlab.freedesktop.org/monado/monado/-/tree/v25.1.0?ref_type=tags>
