### PR TITLE
Revert "Work around armv7 build issues"

### DIFF
--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -114,8 +114,7 @@ ENV RUSTUP_HOME="/opt/rust" \
     CARGO_HOME="/opt/rust" \
     PATH="/opt/rust/bin:${PATH}"
 
-RUN ${CURL_DOWNLOAD} https://sh.rustup.rs | sh -s -- -y && \
-    rustup default 1.94.0 && \
+RUN rustup default 1.94.0 && \
     rustup component remove rust-docs && \
     cargo install --root /usr/local --version 0.14.0 --locked sccache && \
     cargo install --root /usr/local --version 0.10.20 --locked cargo-c

--- a/images/wkdev_sdk/required_system_packages/04-devtools.lst
+++ b/images/wkdev_sdk/required_system_packages/04-devtools.lst
@@ -2,7 +2,7 @@
 build-essential cmake ninja-build
 
 # Build tools
-ccache
+ccache rustup
 
 # Debugging / profiling / tracing
 valgrind perf-tools-unstable systemd-coredump

--- a/images/wkdev_sdk/required_system_packages/05-armv7-jhbuild.lst
+++ b/images/wkdev_sdk/required_system_packages/05-armv7-jhbuild.lst
@@ -1,2 +1,0 @@
-# Needed for jhbuild on armv7
-libyaml-dev desktop-file-utils


### PR DESCRIPTION
This reverts commit e9a63bac4dfcaf59161db7789e515b58b9818486.

Reason for revert:
 - armv7 is not longer supported in native builds of the SDK.