### PR TITLE
Deprecate environment variable WEBKIT_BUILD_USE_SYSTEM_LIBRARIES.

### DIFF
--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -23,13 +23,16 @@ ARG APT_AUTOREMOVE="apt-get --assume-yes autoremove"
 # Disable prompt during package configuration
 ENV DEBIAN_FRONTEND noninteractive
 
-# Used by the WebKit tooling to detect if is running inside the SDK
+# Used by the WebKit tooling to detect if is running inside the SDK.
 ENV WEBKIT_CONTAINER_SDK "1"
 
 # Enable debugging in WebKit's sandbox.
 ENV WEBKIT_ENABLE_DEBUG_PERMISSIONS_IN_SANDBOX "1"
 
-# Used in webkitdirs.pm to prefer building against system libraries instead of the Flatpak SDK.
+# This env var got deprecated in 2026-04 at 309557@main, so remove it when building
+# WebKit older than 309557@main with the last version of the SDK is not longer a need.
+# It was used in webkitdirs.pm to prefer building against system libraries instead of the Flatpak SDK.
+# More details: https://github.com/Igalia/webkit-container-sdk/pull/222
 ENV WEBKIT_BUILD_USE_SYSTEM_LIBRARIES "1"
 
 # Delete the default ubuntu user which has a UID of 1000.


### PR DESCRIPTION
This is not longer needed since https://commits.webkit.org/309557@main
The env var used by the WebKit tooling to identify if is running inside the SDK is now `WEBKIT_CONTAINER_SDK`.

However, to allow building older versions of WebKit with the SDK, instead of just removing the variable now, add a comment about the deprecation status with the idea of removing it on the future.