### PR TITLE
Add libvulkan-volk-dev package

### DIFF
--- a/images/wkdev_sdk/required_system_packages/04-devtools.lst
+++ b/images/wkdev_sdk/required_system_packages/04-devtools.lst
@@ -34,3 +34,6 @@ knockd
 
 # For OpenXR tests
 libeigen3-dev glslang-tools libudev-dev libv4l-dev libvulkan-dev
+
+# Vulkan support
+libvulkan-volk-dev


### PR DESCRIPTION
Volk will be used for Vulkan support in WebKit, to allow dynamically loading the Vulkan libraries at runtime and providing extension wrangling, similar to how Epoxy is used for OpenGL.