### PR TITLE
wkdev-setup-vscode: Avoid prompts for dependencies and APT key

### DIFF
--- a/scripts/container-only/wkdev-setup-vscode
+++ b/scripts/container-only/wkdev-setup-vscode
@@ -40,7 +40,7 @@ install_vscode() {
         exit 1
     fi
 
-    if ! sudo apt install /tmp/code.deb; then
+    if ! sudo env DEBIAN_FRONTEND=noninteractive apt-get install --yes /tmp/code.deb; then
         _log_ "Failed to install Visual Studio Code."
         rm /tmp/code.deb
         exit 1


### PR DESCRIPTION
The current version of the VSCode package breaks non-interactivity in two ways:

* It has some dependencies not already in the SDK, namely libwrap0 and socat.
* It asks whether to install the APT signing key for VS Code.

Since wkdev-setup-vscode is typically used as part of `.wkdev-firstrun`, being able to run non-interactive is pretty important, this would cause installation to fail.

This patch:

* Replaces apt with apt-get (apt is not meant for non-interactive use).
* Passes `--yes` to avoid dependency prompts.
* Uses DEBIAN_FRONTEND=noninteractive to avoid the signing key prompt. Instead, it will be answer with the default (yes).

I considered making the latter two conditional on the usage of wkdev-setup-vscode --yes, but in the end decided against it for simplicity and usability reasons: in practice, nobody is going to be bothered by installing socat, and not installing the APT key would prevent the package from being updated.

Fixes https://github.com/Igalia/webkit-container-sdk/issues/227