### PR TITLE
wkdev-enter: use --detach-keys=

### DIFF
--- a/scripts/host-only/wkdev-enter
+++ b/scripts/host-only/wkdev-enter
@@ -75,11 +75,6 @@ build_podman_arguments() {
 
     local -n generic_arguments=${1}
 
-    # On the host, the podman user socket can be used as well:
-    # '--remote' routes podman communication through the socket,
-    # which is supposed to deliver a CLI usage with less latency.
-    is_podman_user_socket_available && generic_arguments+=("--remote")
-
     argsparse_is_option_set "debug" && generic_arguments+=("--log-level debug")
 }
 
@@ -182,6 +177,12 @@ run() {
     else
         podman_exec_arguments+=("--user" "$(id --user --real):$(id --group --real)")
     fi
+
+    # Disable the detach key binding so that Ctrl+P (readline shortcut for history backwards) works
+    # in one single keystroke. The detach behavior is not super useful with podman exec, since you can't
+    # reattach to the current shell, it will print an error when you use it, and it will not clean the
+    # state of the shell.
+    podman_exec_arguments+=("--detach-keys=")
 
     propagate_environment_variables_from_host
 

--- a/utilities/podman.sh
+++ b/utilities/podman.sh
@@ -80,16 +80,3 @@ get_image_id_by_image_name() {
 
 # Get list of all containers by name.
 get_list_of_containers() { run_podman container list --all --format "{{.Names}}"; }
-
-# Does the podman user socket exist?
-is_podman_user_socket_available() {
-
-    local podman_socket="${XDG_RUNTIME_DIR-}/podman/podman.sock"
-
-    # The socket has to exist...
-    [ -S "${podman_socket}" ] || return 1
-
-    # ... and it should be controlled by the systemd user session.
-    systemctl status --user podman.socket &>/dev/null
-    return ${?}
-}


### PR DESCRIPTION
By default podman exec binds Ctrl+p,Ctrl+q to detach. This causes Ctrl+p to not work normally (it is only send to the process once a second key is received, when podman is sure it wasn't part of a Ctrl+p,Ctrl+q sequence).

This can be disabled with `--detach-keys=""`. This patch does that.

Unfortunately, this does not work when podman --remote is used due to a bug in podman (https://github.com/containers/podman/issues/28193) so this patch will only work once that also gets fixed.