### PR TITLE
.gdbinit: Load pretty printers

### DIFF
--- a/images/wkdev_sdk/user_home_directory_defaults/dot-gdbinit
+++ b/images/wkdev_sdk/user_home_directory_defaults/dot-gdbinit
@@ -7,3 +7,15 @@ set python print-stack full
 set debuginfod enabled on
 set sysroot /
 handle SIGUSR1 nostop noprint
+
+# pretty printers for jhbuild dependencies (e.g. glib, GStreamer):
+add-auto-load-safe-path /jhbuild/install/share/gdb/auto-load
+add-auto-load-scripts-directory /jhbuild/install/share/gdb/auto-load
+
+# WebKit pretty printers
+python
+import sys, os
+if os.path.exists("/sdk/webkit/Tools/gdb/webkit.py"):
+    sys.path.insert(0, "/sdk/webkit/Tools/gdb")
+    import webkit
+end


### PR DESCRIPTION
GLib and GStreamer install pretty printers for gdb. However, since we are building both with jhbuild, they were not being found.

This patch adds the necessary code to the .gdbinit init example to load those pretty printers.

WebKit also contains (non-auto-loadable) gdb pretty printers. Since now WebKit lives in a predictable path, we can load them as well, and this is also added to the example.