### PR TITLE
Fix wkdev-update losing shared-dir

### DIFF
--- a/scripts/host-only/wkdev-create
+++ b/scripts/host-only/wkdev-create
@@ -203,7 +203,7 @@ try_process_home_directory() {
 
     # Map given home directory path as container user home directory (eventually separated from host home directory).
     local podman_argument=("--env" "HOST_HOME=/host/home/${container_user_name}")
-    podman_argument+=("--env" "HOST_CONTAINER_HOME_PATH=${container_user_home}")
+    podman_argument+=("--label" "wkdev.home-path=${container_user_home}")
     podman_argument+=("--mount" "type=bind,source=${container_user_home},destination=/home/${container_user_name},rslave")
     podman_argument+=("--mount" "type=bind,source=${HOME},destination=/host/home/${container_user_name},rslave")
 

--- a/scripts/host-only/wkdev-create
+++ b/scripts/host-only/wkdev-create
@@ -206,6 +206,9 @@ try_process_home_directory() {
     podman_argument+=("--label" "wkdev.home-path=${container_user_home}")
     podman_argument+=("--mount" "type=bind,source=${container_user_home},destination=/home/${container_user_name},rslave")
     podman_argument+=("--mount" "type=bind,source=${HOME},destination=/host/home/${container_user_name},rslave")
+    if [ -n "${container_shared_folder-}" ]; then
+        podman_argument+=("--label" "wkdev.shared-dir-path=${container_shared_folder}")
+    fi
 
     # systemctl --user is-enabled <some-service> relies on the accessibility of ~/.config/systemd/user, map it into the container if available.
     [ -d "${HOME}/.config/systemd/user" ] && podman_argument+=("--mount" "type=bind,source=${HOME}/.config/systemd/user,destination=/home/${container_user_name}/.config/systemd/user,rslave")

--- a/scripts/host-only/wkdev-update
+++ b/scripts/host-only/wkdev-update
@@ -12,6 +12,7 @@ source "${WKDEV_SDK}/utilities/podman.sh"
 argsparse_use_option debug        "Enable debug logging for podman (useful to debug container issues)"
 argsparse_use_option trace        "Enable 'xtrace' mode for this script"
 argsparse_use_option force        "Always re-create matching container(s), even when image IDs are up to date"
+argsparse_describe_parameters "container-name?"
 
 argsparse_usage_description="$(cat <<EOF
 << Purpose >>
@@ -26,6 +27,11 @@ process_command_line_arguments() {
     argsparse_allow_no_argument yes
 
     argsparse_parse_options "${@}"
+    if [ ${#program_params[@]} -gt 1 ]; then
+        _abort_ "At most one positional parameter is supported: <container-name>"
+    fi
+
+    target_container_name="${program_params[0]-}"
     argsparse_is_option_set "trace" && set -o xtrace
 }
 
@@ -70,13 +76,26 @@ update_containers_using_image() {
 
     local max_container_name_length=0
     local found_containers_using_image=0
+    local found_target_container=0
     for container_name in $(get_list_of_containers); do
+        if [ -n "${target_container_name}" ] && [ "${container_name}" = "${target_container_name}" ]; then
+            found_target_container=1
+        fi
+
+        if [ -n "${target_container_name}" ] && [ "${container_name}" != "${target_container_name}" ]; then
+            continue
+        fi
+
         local container_image_name_with_tag="$(get_image_name_by_container_name "${container_name}")"
         _log_ "${container_image_name_with_tag} = ${image_name}"
         [ "${container_image_name_with_tag}" = "${image_name}" ] || continue
         found_containers_using_image=$((found_containers_using_image+1))
         [ ${#container_name} -gt ${max_container_name_length} ] && max_container_name_length=${#container_name}
     done
+
+    if [ -n "${target_container_name}" ] && [ ${found_target_container} -eq 0 ]; then
+        _abort_ "Cannot find container '${target_container_name}'"
+    fi
 
     if [ ${found_containers_using_image} -eq 0 ]; then
         _log_ "-> No containers use this image, no need to recreate any of them."
@@ -87,6 +106,10 @@ update_containers_using_image() {
 
     local -A outdated_container_data=()
     for container_name in $(get_list_of_containers); do
+        if [ -n "${target_container_name}" ] && [ "${container_name}" != "${target_container_name}" ]; then
+            continue
+        fi
+
         local container_image_name_with_tag="$(get_image_name_by_container_name "${container_name}")"
         [ "${container_image_name_with_tag}" = "${image_name}" ] || continue
 

--- a/scripts/host-only/wkdev-update
+++ b/scripts/host-only/wkdev-update
@@ -11,6 +11,7 @@ source "${WKDEV_SDK}/utilities/podman.sh"
 
 argsparse_use_option debug        "Enable debug logging for podman (useful to debug container issues)"
 argsparse_use_option trace        "Enable 'xtrace' mode for this script"
+argsparse_use_option force        "Always re-create matching container(s), even when image IDs are up to date"
 
 argsparse_usage_description="$(cat <<EOF
 << Purpose >>
@@ -94,9 +95,18 @@ update_containers_using_image() {
 
         local status="OK"
         local status_color="green"
-        if [ "${existing_image_id}" != "${latest_image_id}" ]; then
+        local should_recreate=0
+        if argsparse_is_option_set "force"; then
+            should_recreate=1
+            status="FORCED"
+            status_color="yellow"
+        elif [ "${existing_image_id}" != "${latest_image_id}" ]; then
+            should_recreate=1
             status="OUTDATED"
             status_color="red"
+        fi
+
+        if [ ${should_recreate} -eq 1 ]; then
 
             local recreate_arguments=()
             recreate_arguments+=("--home" "$(get_podman_container_home_directory_on_host "${container_name}")")

--- a/scripts/host-only/wkdev-update
+++ b/scripts/host-only/wkdev-update
@@ -100,6 +100,13 @@ update_containers_using_image() {
 
             local recreate_arguments=()
             recreate_arguments+=("--home" "$(get_podman_container_home_directory_on_host "${container_name}")")
+
+            local shared_dir
+            shared_dir="$(get_podman_container_shared_directory_on_host "${container_name}")"
+            if [ -n "${shared_dir}" ]; then
+                recreate_arguments+=("--shared-dir" "${shared_dir}")
+            fi
+
             local init_arguments=($(get_podman_container_init_arguments "${container_name}"))
             for arg in "${init_arguments[@]}"; do
                 # wkdev-create --attach passes the --exit-when-done option to .wkdev-init so that

--- a/utilities/podman.sh
+++ b/utilities/podman.sh
@@ -45,16 +45,31 @@ get_podman_container_init_arguments() {
     run_podman inspect --type container --format "{{range .Args}}{{.}} {{end}}" "${container_name}" 2>/dev/null
 }
 
+# Get a label value from an existing container.
+get_podman_container_label_value() {
+
+    local container_name="${1}"
+    local label_name="${2}"
+    run_podman inspect --type container --format "{{with index .Config.Labels \"${label_name}\"}}{{.}}{{end}}" "${container_name}" 2>/dev/null
+}
+
 # Get the location where the home directory for a container is stored on the host.
 get_podman_container_home_directory_on_host() {
 
     local container_name="${1}"
-    local extract_variable="HOST_CONTAINER_HOME_PATH"
-    set -o pipefail
-    run_podman inspect --type container "${container_name}" 2>/dev/null | grep "${extract_variable}" | sed -e "s/.*${extract_variable}=//" | sed -e s'/",//' | head --lines 1
-    local podman_status=${?}
-    set +o pipefail
-    return ${podman_status}
+
+    local home_path
+    home_path="$(get_podman_container_label_value "${container_name}" "wkdev.home-path")"
+    if [ -n "${home_path}" ]; then
+        echo "${home_path}"
+        return 0
+    fi
+
+    # Fallback for legacy containers created before labels were introduced.
+    run_podman inspect --type container --format "{{range .Config.Env}}{{println .}}{{end}}" "${container_name}" 2>/dev/null \
+        | grep '^HOST_CONTAINER_HOME_PATH=' \
+        | sed -e 's/^HOST_CONTAINER_HOME_PATH=//' \
+        | head --lines 1
 }
 
 # Get currently used image name given an container name.

--- a/utilities/podman.sh
+++ b/utilities/podman.sh
@@ -72,6 +72,11 @@ get_podman_container_home_directory_on_host() {
         | head --lines 1
 }
 
+get_podman_container_shared_directory_on_host() {
+
+    get_podman_container_label_value "${1}" "wkdev.shared-dir-path"
+}
+
 # Get currently used image name given an container name.
 get_image_name_by_container_name() {
 


### PR DESCRIPTION
It gets the old home but not its shared-dir, so now we persist that in the metadata.

Added arguments just to help with testing, so you can do `wkdev-update --force wkdev`