### PR TITLE
Replace clang-21 with clang-22 in the SDK

### DIFF
--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -62,7 +62,7 @@ RUN dpkg-reconfigure locales
 # Ensure a strong TLS connection is always used when downloading sensitive files.
 ARG CURL_DOWNLOAD="curl --proto =https --tlsv1.2 --show-error --silent --fail"
 
-# Add LLVM repo for clang packages (clang-21 requires apt.llvm.org).
+# Add LLVM repo for clang packages (clang-22 requires apt.llvm.org).
 COPY /rootfs/etc/apt/sources.list.d/llvm.list /etc/apt/sources.list.d/llvm.list
 RUN ${CURL_DOWNLOAD} https://apt.llvm.org/llvm-snapshot.gpg.key -o /etc/apt/trusted.gpg.d/apt.llvm.org.asc
 

--- a/images/wkdev_sdk/required_system_packages/03-clang.lst
+++ b/images/wkdev_sdk/required_system_packages/03-clang.lst
@@ -1,6 +1,6 @@
 # Clang toolchain (current version: 18)
 clang-18 clangd-18 clang-format-18 clang-tidy-18 lld-18
 
-# Add most recent clang version (current version 21) -- it's not set as default (see Containerfile)
-# Ubuntu provided lldb-18 and LLVM-provided lldb-21 are in conflict - however we can just pull in lldb-21, which works with clang-18 too.
-clang-21 clangd-21 clang-format-21 clang-tidy-21 lld-21 lldb-21
+# Add most recent clang version (current version 22) -- it's not set as default (see Containerfile)
+# Ubuntu provided lldb-18 and LLVM-provided lldb-22 are in conflict - however we can just pull in lldb-22, which works with clang-18 too.
+clang-22 clangd-22 clang-format-22 clang-tidy-22 lld-22 lldb-22

--- a/images/wkdev_sdk/rootfs/etc/apt/sources.list.d/llvm.list
+++ b/images/wkdev_sdk/rootfs/etc/apt/sources.list.d/llvm.list
@@ -10,3 +10,6 @@ deb-src http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main
 # 21
 deb http://apt.llvm.org/noble/ llvm-toolchain-noble-21 main
 deb-src http://apt.llvm.org/noble/ llvm-toolchain-noble-21 main
+# 22
+deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main
+deb-src http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main


### PR DESCRIPTION
clang-21 was added in order to have the latest version of clang in the SDK. For some time now clang-22 is available and can be fetched from the LLVM apt sources list, so replace clang-21 with it.

People who want to continue using clang-21 can still install it with wkdev-setup-clang.