### PR TITLE
Add wkdev-find-buildbot-worker-base helper script

### DIFF
--- a/scripts/host-only/wkdev-find-buildbot-worker-base
+++ b/scripts/host-only/wkdev-find-buildbot-worker-base
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+# Copyright 2026 Igalia S.L.
+# SPDX-License: MIT
+#
+# Given a buildbot-worker version tag, resolve which wkdev-sdk base image
+# (by manifest digest) it was built on top of.
+#
+# Strategy:
+#   1. Fetch the buildbot-worker image config and find the history boundary
+#      between the base wkdev-sdk layers and the buildbot-worker Dockerfile
+#      steps. The marker is the `LABEL org.opencontainers.image.version=<ver>`
+#      line produced by the buildbot-worker Dockerfile.
+#   2. Take the first N layers of the image manifest (N = non-empty history
+#      entries before the boundary). Those are the base image's layers.
+#   3. List every wkdev-sdk manifest (tagged *and* untagged) via the GitHub
+#      Packages REST API and find the one whose layers match.
+#
+# Requires a GitHub token with `read:packages` scope. Discovered in this order:
+#   - $GITHUB_TOKEN
+#   - `gh auth token`
+#   - ghcr.io entry in containers/auth.json (populated by `podman login ghcr.io`)
+
+import argparse
+import base64
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+ORG = "igalia"
+BUILDBOT_WORKER_REPO = f"ghcr.io/{ORG}/buildbot-worker"
+WKDEV_SDK_REPO = f"ghcr.io/{ORG}/wkdev-sdk"
+WKDEV_SDK_PKG = "wkdev-sdk"
+GH_REPO = "Igalia/webkit-container-sdk"
+GH_WORKFLOW = "wkdev-sdk.yml"
+
+
+def run_json(cmd):
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"{' '.join(cmd)} failed:\n{result.stderr.strip()}")
+    return json.loads(result.stdout)
+
+
+def inspect(ref):
+    return run_json(["skopeo", "inspect", f"docker://{ref}"])
+
+
+def inspect_config(ref):
+    return run_json(["skopeo", "inspect", "--config", f"docker://{ref}"])
+
+
+def find_base_layer_count(history, version):
+    """Count non-empty history entries before the buildbot-worker Dockerfile.
+
+    The buildbot-worker Dockerfile starts with
+    `LABEL org.opencontainers.image.version=<version>`; everything before that
+    came from the base wkdev-sdk image.
+    """
+    marker = f"LABEL org.opencontainers.image.version={version}"
+    for i, entry in enumerate(history):
+        if marker in entry.get("created_by", ""):
+            return sum(1 for e in history[:i] if not e.get("empty_layer"))
+    raise RuntimeError(f"Could not locate boundary marker in image history: {marker!r}")
+
+
+def discover_github_token():
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        return token
+
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"], capture_output=True, text=True, check=True
+        )
+        token = result.stdout.strip()
+        if token:
+            return token
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        pass
+
+    candidates = []
+    xdg_runtime = os.environ.get("XDG_RUNTIME_DIR")
+    if xdg_runtime:
+        candidates.append(os.path.join(xdg_runtime, "containers", "auth.json"))
+    candidates.append(os.path.expanduser("~/.config/containers/auth.json"))
+    candidates.append(os.path.expanduser("~/.docker/config.json"))
+
+    for path in candidates:
+        if not os.path.isfile(path):
+            continue
+        try:
+            data = json.load(open(path))
+        except (OSError, json.JSONDecodeError):
+            continue
+        entry = data.get("auths", {}).get("ghcr.io")
+        if not entry or "auth" not in entry:
+            continue
+        try:
+            decoded = base64.b64decode(entry["auth"]).decode()
+        except (ValueError, UnicodeDecodeError):
+            continue
+        if ":" in decoded:
+            return decoded.split(":", 1)[1]
+
+    return None
+
+
+def gh_api_get(url, token):
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(req) as resp:
+        return json.load(resp), resp.headers.get("Link", "")
+
+
+def list_all_package_versions(org, package, token):
+    versions = []
+    url = (
+        f"https://api.github.com/orgs/{org}/packages/container/"
+        f"{package}/versions?per_page=100"
+    )
+    while url:
+        page, link = gh_api_get(url, token)
+        versions.extend(page)
+        url = None
+        for part in link.split(","):
+            if 'rel="next"' in part:
+                url = part.split(";", 1)[0].strip().strip("<>")
+                break
+    return versions
+
+
+def find_workflow_run_for(created_iso, token):
+    """Return the workflow run whose time window contains created_iso.
+
+    The SDK image's `Created` is the timestamp recorded by `podman build`
+    inside the job, so it lies between the run's `run_started_at` and
+    `updated_at`.
+    """
+    day = created_iso[:10]
+    prev = (
+        f"{int(day[:4]):04d}-{day[5:7]}-{max(1, int(day[8:10]) - 1):02d}"
+    )
+    nxt = f"{day[:8]}{min(31, int(day[8:10]) + 1):02d}"
+    url = (
+        f"https://api.github.com/repos/{GH_REPO}/actions/workflows/"
+        f"{GH_WORKFLOW}/runs?per_page=100&status=success"
+        f"&created={prev}..{nxt}"
+    )
+    while url:
+        try:
+            page, link = gh_api_get(url, token)
+        except urllib.error.HTTPError:
+            return None
+        for run in page.get("workflow_runs", []):
+            if run["run_started_at"] <= created_iso <= run["updated_at"]:
+                return run
+        url = None
+        for part in link.split(","):
+            if 'rel="next"' in part:
+                url = part.split(";", 1)[0].strip().strip("<>")
+                break
+    return None
+
+
+def local_commit_summary(sha):
+    """Return `<short-sha> <subject>` if the commit is in the local repo."""
+    try:
+        out = subprocess.check_output(
+            ["git", "log", "-1", "--format=%h %s", sha],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        return out.strip()
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Resolve the wkdev-sdk base image digest for a buildbot-worker version.",
+    )
+    parser.add_argument("version", help="buildbot-worker version tag, e.g. 2.40.0")
+    args = parser.parse_args()
+
+    worker_ref = f"{BUILDBOT_WORKER_REPO}:{args.version}"
+    print(f"Inspecting {worker_ref} ...", file=sys.stderr)
+
+    try:
+        worker = inspect(worker_ref)
+        worker_config = inspect_config(worker_ref)
+    except RuntimeError as e:
+        sys.exit(str(e))
+
+    base_count = find_base_layer_count(
+        worker_config.get("history", []), args.version
+    )
+    base_layers = worker["Layers"][:base_count]
+    worker_created = worker.get("Created", "")
+
+    token = discover_github_token()
+    if not token:
+        sys.exit(
+            "No GitHub token found. Set GITHUB_TOKEN, run `gh auth login`, "
+            "or `podman login ghcr.io` with a PAT that has read:packages scope."
+        )
+
+    try:
+        versions = list_all_package_versions(ORG, WKDEV_SDK_PKG, token)
+    except urllib.error.HTTPError as e:
+        sys.exit(f"GitHub API error: {e} — token may lack read:packages scope.")
+
+    # Base must be older than the buildbot-worker image. Sort newest-first
+    # and skip anything created after the worker image.
+    versions.sort(key=lambda v: v.get("created_at", ""), reverse=True)
+
+    print(
+        f"Scanning {len(versions)} wkdev-sdk manifests from GHCR ...",
+        file=sys.stderr,
+    )
+
+    for v in versions:
+        if worker_created and v.get("created_at", "") > worker_created:
+            continue
+        digest = v["name"]
+        try:
+            sdk = inspect(f"{WKDEV_SDK_REPO}@{digest}")
+        except RuntimeError:
+            continue
+        if sdk.get("Layers") == base_layers:
+            tags = v.get("metadata", {}).get("container", {}).get("tags", [])
+            tag_note = f"wkdev-sdk:{','.join(tags)}" if tags else "wkdev-sdk (untagged)"
+            print(
+                f"Found it. buildbot-worker:{args.version} was built on top of "
+                f"{tag_note}:"
+            )
+            print()
+            print(f"  {digest} (created {sdk['Created']})")
+
+            run = find_workflow_run_for(sdk["Created"], token)
+            if run:
+                sha = run["head_sha"]
+                print()
+                print(
+                    f"  Built by workflow run on {run['head_branch']} "
+                    f"(event={run['event']}):"
+                )
+                print(f"    commit: {sha}")
+                summary = local_commit_summary(sha)
+                if summary:
+                    print(f"            {summary}")
+                print(f"    run:    {run['html_url']}")
+            else:
+                print()
+                print(
+                    "  No matching workflow run found — image may have been "
+                    "built/pushed outside GitHub Actions."
+                )
+            return
+
+    sys.exit(
+        f"No wkdev-sdk manifest in GHCR matches the base layers of "
+        f"buildbot-worker:{args.version}. The base may have been deleted."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Given a buildbot-worker version, resolves which wkdev-sdk base image digest it was built on top of (even if no longer tagged) and the source commit / GitHub Actions run that produced that base image.