### PR TITLE
Bump to librice 0.4.3

### DIFF
--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -135,7 +135,7 @@ RUN rustup default 1.94.0 && \
 
 RUN git clone https://github.com/ystreet/librice.git && \
     cd librice && \
-    git checkout v0.4.2 && \
+    git checkout v0.4.3 && \
     cargo cinstall -p rice-proto --release --prefix=/usr --libdir=lib/$(gcc -dumpmachine) --library-type=cdylib && \
     cargo cinstall -p rice-io --release --prefix=/usr --libdir=lib/$(gcc -dumpmachine) --library-type=cdylib && \
     cd .. && \


### PR DESCRIPTION
Among other things it includes new rice-io API that we need in WebKit.