### PR TITLE
Allow any user to write in /sdk

### DIFF
--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -211,10 +211,10 @@ RUN mkdir -p /usr/share/wkdev-sdk/cross/armhf && \
 RUN find /etc/systemd/ -type l -name '*.service' -print -exec rm {} \;
 
 # Create the /sdk common-directory to help with ccache/sccache artifact sharing
-RUN mkdir /sdk
+RUN mkdir /sdk && chmod 777 /sdk
 
 # Change the owner to UID 1000 as a fast path
-RUN chown --recursive 1000:1000 ${RUSTUP_HOME} /jhbuild /sdk
+RUN chown --recursive 1000:1000 ${RUSTUP_HOME} /jhbuild
 
 # Switch back to interactive prompt, when using apt.
 ENV DEBIAN_FRONTEND dialog

--- a/scripts/container-only/.wkdev-init
+++ b/scripts/container-only/.wkdev-init
@@ -219,20 +219,6 @@ try_setup_permissions_rust_directory() {
     fi
 }
 
-try_setup_root_sdk_directory() {
-
-    local root_sdk_directory="/sdk"
-
-    task_step "Setup '${root_sdk_directory}' directory permissions..."
-
-    if sudo -u "${container_user_name}" test -w "${root_sdk_directory}"; then
-        echo "      -> Already writable, skipping."
-    else
-        chown "${container_user_name}:${container_group_name}" "${root_sdk_directory}"
-    fi
-}
-
-
 try_firstrun_script() {
 
     local user_home
@@ -268,7 +254,6 @@ TASKS=(
     "try_setup_dockerenv_file"
     "try_setup_permissions_jhbuild_directory"
     "try_setup_permissions_rust_directory"
-    "try_setup_root_sdk_directory"
     "try_firstrun_script"
 )
 


### PR DESCRIPTION
Since https://commits.webkit.org/313275@main we are supporting launching ephemeral containers that do not have a init phase with root access.

So to allow the /sdk common directory to work in that case we need to grant read-write permissions for everybody in this diretory.