### PR TITLE
CI: Clean up podman storage after build/deploy jobs

### DIFF
--- a/.github/workflows/build-and-publish-wkdev-sdk-image.yaml
+++ b/.github/workflows/build-and-publish-wkdev-sdk-image.yaml
@@ -7,6 +7,10 @@ on:
   pull_request:
     paths-ignore: [ docs/**, README.md ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     strategy:
@@ -23,60 +27,58 @@ jobs:
       packages: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
 
-      - name: Login to registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+    - name: Log in to GitHub Container Registry
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
-      - name: Resolve version & registry coordinates
-        run: |
-          VERSION=$(./scripts/helpers/print-sdk-version)
-          echo "WKDEV_SDK_VERSION=${VERSION}" >> "${GITHUB_ENV}"
-          echo "REPO=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/wkdev-sdk" >> "${GITHUB_ENV}"
+    - name: Resolve version & registry coordinates
+      run: |
+        VERSION=$(./scripts/helpers/print-sdk-version)
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+        echo "GHCR_REPO=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+        echo "IMAGE_WITH_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/wkdev-sdk:${VERSION}" >> $GITHUB_ENV
 
-          if [[ "${GITHUB_REF}" == refs/tags/wkdev-sdk-* ]]; then
-            TAG_VERSION="${GITHUB_REF#refs/tags/wkdev-sdk-}"
-            if [ "${TAG_VERSION}" != "${VERSION}" ]; then
-              echo "Error: git tag wkdev-sdk-${TAG_VERSION} does not match Containerfile WKDEV_SDK_VERSION=${VERSION}"
-              exit 1
-            fi
+        if [[ "${GITHUB_REF}" == refs/tags/wkdev-sdk-* ]]; then
+          TAG_VERSION="${GITHUB_REF#refs/tags/wkdev-sdk-}"
+          if [ "${TAG_VERSION}" != "${VERSION}" ]; then
+            echo "Error: git tag wkdev-sdk-${TAG_VERSION} does not match Containerfile WKDEV_SDK_VERSION=${VERSION}"
+            exit 1
           fi
+        fi
 
-      - name: Install podman
-        run: sudo apt-get update && sudo apt-get -y install podman fuse-overlayfs
+    - name: Build image
+      run: |
+        podman build --jobs $(nproc) --build-context scripts=./scripts \
+          --build-arg WKDEV_SDK_VERSION=${{ env.VERSION }} \
+          -t ${{ env.IMAGE_WITH_TAG }}_${{ matrix.arch }} --arch=${{ matrix.arch }} images/wkdev_sdk
+        podman image list
 
-      - name: Build image
-        run: |
-          podman build --jobs $(nproc) --build-context scripts=./scripts \
-            --build-arg WKDEV_SDK_VERSION=${{ env.WKDEV_SDK_VERSION }} \
-            -t ${{ env.REPO }}:${{ env.WKDEV_SDK_VERSION }}_${{ matrix.arch }} --arch=${{ matrix.arch }} images/wkdev_sdk
-          podman image list
+    - name: Test image
+      run: |
+        CONTAINER="wkdev-$(date +%s)"
+        echo "CONTAINER=${CONTAINER}" >> $GITHUB_ENV
+        source ./register-sdk-on-host.sh
+        wkdev-create --create-home --home ${HOME}/${CONTAINER}-home --verbose --attach --no-pull --name ${CONTAINER} --arch ${{ matrix.arch }}
+        wkdev-enter -n ${CONTAINER} --exec -- git clone --depth=1 https://github.com/WebKit/WebKit.git
+        wkdev-enter -n ${CONTAINER} --exec -- ./WebKit/Tools/Scripts/build-webkit --wpe --release --generate-project-only
+        wkdev-enter -n ${CONTAINER} --exec -- ./WebKit/Tools/Scripts/build-webkit --gtk --release --generate-project-only
 
-      - name: Test image
-        run: |
-          CONTAINER="wkdev-$(date +%s)"
-          echo "CONTAINER=${CONTAINER}" >> "${GITHUB_ENV}"
-          source ./register-sdk-on-host.sh
-          wkdev-create --create-home --home ${HOME}/${CONTAINER}-home --verbose --attach --no-pull --name ${CONTAINER} --arch ${{ matrix.arch }}
-          wkdev-enter -n ${CONTAINER} --exec -- git clone --depth=1 https://github.com/WebKit/WebKit.git
-          wkdev-enter -n ${CONTAINER} --exec -- ./WebKit/Tools/Scripts/build-webkit --wpe --release --generate-project-only
-          wkdev-enter -n ${CONTAINER} --exec -- ./WebKit/Tools/Scripts/build-webkit --gtk --release --generate-project-only
+    - name: Push image
+      if: startsWith(github.ref, 'refs/tags/wkdev-sdk-')
+      run: podman push ${{ env.IMAGE_WITH_TAG }}_${{ matrix.arch }}
 
-      - name: Push image
-        if: startsWith(github.ref, 'refs/tags/wkdev-sdk-')
-        run: podman push ${{ env.REPO }}:${{ env.WKDEV_SDK_VERSION }}_${{ matrix.arch }}
-
-      - name: Cleanup test artifacts
-        if: always()
-        run: |
-          if [ -n "${{ env.CONTAINER }}" ]; then
-            podman rm --force ${{ env.CONTAINER }} 2>/dev/null || true
-            rm -rf ${HOME}/${{ env.CONTAINER }}-home || true
-          fi
-          # Clean up any leftover containers and home directories from previous failed runs
-          podman ps -a --filter "name=^wkdev-" --format "{{.Names}}" | xargs -r podman rm --force 2>/dev/null || true
-          find ${HOME} -maxdepth 1 -type d -name "wkdev-*-home" -exec rm -rf {} + 2>/dev/null || true
+    - name: Clean up test artifacts
+      if: always()
+      run: |
+        if [ -n "${{ env.CONTAINER }}" ]; then
+          podman rm --force ${{ env.CONTAINER }} 2>/dev/null || true
+          rm -rf ${HOME}/${{ env.CONTAINER }}-home || true
+        fi
+        # Clean up any leftover containers and home directories from previous failed runs
+        podman ps -a --filter "name=^wkdev-" --format "{{.Names}}" | xargs -r podman rm --force 2>/dev/null || true
+        find ${HOME} -maxdepth 1 -type d -name "wkdev-*-home" -exec rm -rf {} + 2>/dev/null || true
 
   deploy:
     runs-on: [self-hosted, x64]
@@ -87,95 +89,97 @@ jobs:
       packages: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
 
-      - name: Resolve version & registry coordinates
-        run: |
-          VERSION="${GITHUB_REF#refs/tags/wkdev-sdk-}"
-          echo "WKDEV_SDK_VERSION=${VERSION}" >> "${GITHUB_ENV}"
-          echo "GHCR_REPO=${GITHUB_REPOSITORY_OWNER,,}" >> "${GITHUB_ENV}"
-          echo "REPO=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/wkdev-sdk" >> "${GITHUB_ENV}"
+    - name: Log in to GitHub Container Registry
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | skopeo login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
-      - name: Install podman and skopeo
-        run: sudo apt-get update && sudo apt-get -y install podman fuse-overlayfs skopeo
+    - name: Resolve version & registry coordinates
+      run: |
+        VERSION="${GITHUB_REF#refs/tags/wkdev-sdk-}"
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+        echo "GHCR_REPO=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+        echo "IMAGE_WITH_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/wkdev-sdk:${VERSION}" >> $GITHUB_ENV
 
-      - name: Login to registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | skopeo login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+    - name: Validate all architecture images exist in registry
+      id: validate
+      run: |
+        skopeo inspect docker://${{ env.IMAGE_WITH_TAG }}_amd64 > /dev/null 2>&1 &
+        pid_amd64=$!
+        skopeo inspect docker://${{ env.IMAGE_WITH_TAG }}_arm64 > /dev/null 2>&1 &
+        pid_arm64=$!
+        rc_amd64=0; wait ${pid_amd64} || rc_amd64=$?
+        rc_arm64=0; wait ${pid_arm64} || rc_arm64=$?
+        [ ${rc_amd64} -eq 0 ] && echo "Validated: ${{ env.IMAGE_WITH_TAG }}_amd64 exists in registry" \
+                              || echo "Error: Image ${{ env.IMAGE_WITH_TAG }}_amd64 does not exist in registry"
+        [ ${rc_arm64} -eq 0 ] && echo "Validated: ${{ env.IMAGE_WITH_TAG }}_arm64 exists in registry" \
+                              || echo "Error: Image ${{ env.IMAGE_WITH_TAG }}_arm64 does not exist in registry"
+        if [ ${rc_amd64} -ne 0 ] || [ ${rc_arm64} -ne 0 ]; then
+          echo "validation_failed=true" >> $GITHUB_OUTPUT
+          exit 1
+        fi
+        echo "validation_failed=false" >> $GITHUB_OUTPUT
 
-      - name: Validate all architecture images exist in registry
-        id: validate
-        run: |
-          skopeo inspect docker://${{ env.REPO }}:${{ env.WKDEV_SDK_VERSION }}_amd64 > /dev/null 2>&1 &
-          pid_amd64=$!
-          skopeo inspect docker://${{ env.REPO }}:${{ env.WKDEV_SDK_VERSION }}_arm64 > /dev/null 2>&1 &
-          pid_arm64=$!
-          rc_amd64=0; wait ${pid_amd64} || rc_amd64=$?
-          rc_arm64=0; wait ${pid_arm64} || rc_arm64=$?
-          [ ${rc_amd64} -eq 0 ] && echo "Validated: ${{ env.REPO }}:${{ env.WKDEV_SDK_VERSION }}_amd64 exists in registry" \
-                                || echo "Error: Image ${{ env.REPO }}:${{ env.WKDEV_SDK_VERSION }}_amd64 does not exist in registry"
-          [ ${rc_arm64} -eq 0 ] && echo "Validated: ${{ env.REPO }}:${{ env.WKDEV_SDK_VERSION }}_arm64 exists in registry" \
-                                || echo "Error: Image ${{ env.REPO }}:${{ env.WKDEV_SDK_VERSION }}_arm64 does not exist in registry"
-          if [ ${rc_amd64} -ne 0 ] || [ ${rc_arm64} -ne 0 ]; then
-            echo "validation_failed=true" >> $GITHUB_OUTPUT
-            exit 1
-          fi
-          echo "validation_failed=false" >> $GITHUB_OUTPUT
+    - name: Clean up arch-specific images on validation failure (amd64)
+      if: failure() && steps.validate.outputs.validation_failed == 'true'
+      continue-on-error: true
+      uses: bots-house/ghcr-delete-image-action@v1.1.0
+      with:
+        owner: ${{ env.GHCR_REPO }}
+        name: wkdev-sdk
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ env.VERSION }}_amd64
 
-      - name: Clean up arch-specific images on validation failure (amd64)
-        if: failure() && steps.validate.outputs.validation_failed == 'true'
-        continue-on-error: true
-        uses: bots-house/ghcr-delete-image-action@v1.1.0
-        with:
-          owner: ${{ env.GHCR_REPO }}
-          name: wkdev-sdk
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.WKDEV_SDK_VERSION }}_amd64
+    - name: Clean up arch-specific images on validation failure (arm64)
+      if: failure() && steps.validate.outputs.validation_failed == 'true'
+      continue-on-error: true
+      uses: bots-house/ghcr-delete-image-action@v1.1.0
+      with:
+        owner: ${{ env.GHCR_REPO }}
+        name: wkdev-sdk
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ env.VERSION }}_arm64
 
-      - name: Clean up arch-specific images on validation failure (arm64)
-        if: failure() && steps.validate.outputs.validation_failed == 'true'
-        continue-on-error: true
-        uses: bots-house/ghcr-delete-image-action@v1.1.0
-        with:
-          owner: ${{ env.GHCR_REPO }}
-          name: wkdev-sdk
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.WKDEV_SDK_VERSION }}_arm64
+    - name: Pull arch-specific images to local storage
+      run: |
+        declare -A pids
+        for arch in amd64 arm64; do
+          podman pull ${{ env.IMAGE_WITH_TAG }}_${arch} &
+          pids[${arch}]=$!
+        done
+        for arch in amd64 arm64; do
+          wait ${pids[${arch}]} || { echo "${arch} pull failed"; exit 1; }
+        done
 
-      - name: Pull arch-specific images to local storage
-        run: |
-          declare -A pids
-          for arch in amd64 arm64; do
-            podman pull ${{ env.REPO }}:${{ env.WKDEV_SDK_VERSION }}_${arch} &
-            pids[${arch}]=$!
-          done
-          for arch in amd64 arm64; do
-            wait ${pids[${arch}]} || { echo "${arch} pull failed"; exit 1; }
-          done
+    - name: Delete arch-specific tag (amd64)
+      uses: bots-house/ghcr-delete-image-action@v1.1.0
+      with:
+        owner: ${{ env.GHCR_REPO }}
+        name: wkdev-sdk
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ env.VERSION }}_amd64
 
-      - name: Delete arch-specific tag (amd64)
-        uses: bots-house/ghcr-delete-image-action@v1.1.0
-        with:
-          owner: ${{ env.GHCR_REPO }}
-          name: wkdev-sdk
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.WKDEV_SDK_VERSION }}_amd64
+    - name: Delete arch-specific tag (arm64)
+      uses: bots-house/ghcr-delete-image-action@v1.1.0
+      with:
+        owner: ${{ env.GHCR_REPO }}
+        name: wkdev-sdk
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ env.VERSION }}_arm64
 
-      - name: Delete arch-specific tag (arm64)
-        uses: bots-house/ghcr-delete-image-action@v1.1.0
-        with:
-          owner: ${{ env.GHCR_REPO }}
-          name: wkdev-sdk
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.WKDEV_SDK_VERSION }}_arm64
+    - name: Create multi-arch manifest from local storage
+      run: |
+        podman manifest create ${{ env.IMAGE_WITH_TAG }}
+        for arch in amd64 arm64; do
+          podman manifest add ${{ env.IMAGE_WITH_TAG }} containers-storage:${{ env.IMAGE_WITH_TAG }}_${arch}
+        done
 
-      - name: Create multi-arch manifest from local storage
-        run: |
-          podman manifest create ${{ env.REPO }}:${{ env.WKDEV_SDK_VERSION }}
-          for arch in amd64 arm64; do
-            podman manifest add ${{ env.REPO }}:${{ env.WKDEV_SDK_VERSION }} containers-storage:${{ env.REPO }}:${{ env.WKDEV_SDK_VERSION }}_${arch}
-          done
+    - name: Push self-contained multi-arch manifest with all layers
+      run: |
+        podman manifest push --all ${{ env.IMAGE_WITH_TAG }} docker://${{ env.IMAGE_WITH_TAG }}
 
-      - name: Push self-contained multi-arch manifest with all layers
-        run: |
-          podman manifest push --all ${{ env.REPO }}:${{ env.WKDEV_SDK_VERSION }} docker://${{ env.REPO }}:${{ env.WKDEV_SDK_VERSION }}
+    - name: Remove local artifacts produced by this deploy
+      run: |
+        podman manifest rm ${{ env.IMAGE_WITH_TAG }} 2>/dev/null || true
+        podman rmi --force ${{ env.IMAGE_WITH_TAG }}_amd64 ${{ env.IMAGE_WITH_TAG }}_arm64 2>/dev/null || true

--- a/.github/workflows/release-wkdev-sdk.yaml
+++ b/.github/workflows/release-wkdev-sdk.yaml
@@ -11,6 +11,7 @@ env:
   CONTAINERFILE_PATH: images/wkdev_sdk/Containerfile
 
 jobs:
+  # Phase 1: Image Version Bump and Tag
   bump-image-version:
     runs-on: ubuntu-latest
     permissions:
@@ -70,6 +71,7 @@ jobs:
         git push origin "${TAG_NAME}"
         echo "Created tag: ${TAG_NAME}"
 
+  # Phase 2: Wait for Image Build Workflow
   wait-for-image-build:
     needs: bump-image-version
     runs-on: ubuntu-latest
@@ -121,6 +123,9 @@ jobs:
 
         echo "Image build workflow completed successfully!"
 
+  # ============================================================
+  # Summary Job
+  # ============================================================
   release-summary:
     needs: [bump-image-version, wait-for-image-build]
     runs-on: ubuntu-latest


### PR DESCRIPTION
The wkdev-sdk image-build workflow runs on self-hosted runners on every PR but pushes to GHCR only on tags, so PR builds left their image layers behind on the runners (the existing "Cleanup test artifacts" step removed test containers and home dirs but not the built image). The deploy job likewise pulled both arch images for manifest assembly and never removed them. Both jobs now remove what they produced, run podman system prune to sweep stopped containers, dangling layers, unused networks and dangling build cache, and print labelled disk-usage reporting at the end.

The shared cleanup logic lives in a local composite action at .github/actions/podman-cleanup, so each job invokes it with only the per-job manifest/image inputs. While I'm at it, cleanup formatting, style etc to be similar to all the other workflows in webkit-container-sdk-bots.

Also adds a concurrency group that cancels superseded PR runs (push tags are not cancelled) so a rapid succession of pushes to the same PR doesn't stack multiple in-flight builds on the same runner.

This should improve the disk space situation in the future.