### PR TITLE
Define env vars DEBUGINFOD_URLS and PIP_BREAK_SYSTEM_PACKAGES in the Containerfile

### DIFF
--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -40,6 +40,12 @@ ENV WEBKIT_CONTAINER_SDK "1"
 # Enable debugging in WebKit's sandbox.
 ENV WEBKIT_ENABLE_DEBUG_PERMISSIONS_IN_SANDBOX "1"
 
+# For improved experience using GDB.
+ENV DEBUGINFOD_URLS "https://debuginfod.ubuntu.com"
+
+# Otherwise one has to pass --break-system-packages to python, when installing custom packages.
+ENV PIP_BREAK_SYSTEM_PACKAGES 1
+
 # This env var got deprecated in 2026-04 at 309557@main, so remove it when building
 # WebKit older than 309557@main with the last version of the SDK is not longer a need.
 # It was used in webkitdirs.pm to prefer building against system libraries instead of the Flatpak SDK.
@@ -121,7 +127,7 @@ RUN sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.s
     ${APT_AUTOREMOVE}
 
 # GStreamer 1.26.x requires at least Meson 1.4. Install the latest version.
-RUN pip install meson==1.8.2 --break-system-packages
+RUN pip install meson==1.8.2
 
 # Add Rust environment.
 ENV RUSTUP_HOME="/opt/rust" \

--- a/images/wkdev_sdk/user_home_directory_defaults/dot-bash_profile
+++ b/images/wkdev_sdk/user_home_directory_defaults/dot-bash_profile
@@ -1,8 +1,3 @@
-export DEBUGINFOD_URLS="https://debuginfod.ubuntu.com"
-
-# Otherwise one has to pass --break-system-packages to python, when installing custom packages.
-export PIP_BREAK_SYSTEM_PACKAGES=1
-
 # wkdev-sdk integration
 export WKDEV_SDK=/wkdev-sdk
 export PATH="${WKDEV_SDK}/scripts:${WKDEV_SDK}/scripts/container-only:$(python3 -m site --user-base)/bin:${PATH}"

--- a/images/wkdev_sdk/user_home_directory_defaults/dot-zprofile
+++ b/images/wkdev_sdk/user_home_directory_defaults/dot-zprofile
@@ -1,8 +1,3 @@
-export DEBUGINFOD_URLS="https://debuginfod.ubuntu.com"
-
-# Otherwise one has to pass --break-system-packages to python, when installing custom packages.
-export PIP_BREAK_SYSTEM_PACKAGES=1
-
 # wkdev-sdk integration
 export WKDEV_SDK=/wkdev-sdk
 export PATH="${WKDEV_SDK}/scripts:${WKDEV_SDK}/scripts/container-only:$(python3 -m site --user-base)/bin:${PATH}"

--- a/images/wkdev_sdk/user_home_directory_defaults/fish-config
+++ b/images/wkdev_sdk/user_home_directory_defaults/fish-config
@@ -1,8 +1,3 @@
-set --export DEBUGINFOD_URLS "https://debuginfod.ubuntu.com"
-
-# Otherwise one has to pass --break-system-packages to python, when installing custom packages.
-set --export PIP_BREAK_SYSTEM_PACKAGES 1
-
 fish_add_path "$(python3 -m site --user-base)/bin"
 
 # wkdev-sdk integration


### PR DESCRIPTION
That way this env vars are also available on the ephemeral SDK containers for the infra.
`DEBUGINFOD_URLS` is needed there to be able to fetch automatically debug info from the system libraries