### PR TITLE
CI: Publish per-PR wkdev-sdk images to ghcr.io

### DIFF
--- a/.github/workflows/build-and-publish-wkdev-sdk-image.yaml
+++ b/.github/workflows/build-and-publish-wkdev-sdk-image.yaml
@@ -11,6 +11,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  # Release tags (e.g. 2.53-v5-3bdf4b8) and per-PR tags (pr-<N>-<sha>) coexist
+  # in this one image; the 'pr-' prefix is the distinguisher.
+  IMAGE_NAME: wkdev-sdk
+
 jobs:
   build:
     strategy:
@@ -25,6 +30,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      registry_tag: ${{ steps.resolve.outputs.registry_tag }}
 
     steps:
     - name: Checkout repository
@@ -34,19 +41,41 @@ jobs:
       run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
     - name: Resolve version & registry coordinates
+      id: resolve
+      env:
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
-        VERSION=$(./scripts/helpers/print-sdk-version)
-        echo "VERSION=${VERSION}" >> $GITHUB_ENV
-        echo "GHCR_REPO=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
-        echo "IMAGE_WITH_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/wkdev-sdk:${VERSION}" >> $GITHUB_ENV
-
         if [[ "${GITHUB_REF}" == refs/tags/wkdev-sdk-* ]]; then
+          VERSION=$(./scripts/helpers/print-sdk-version)
+          REGISTRY_TAG="${VERSION}"
           TAG_VERSION="${GITHUB_REF#refs/tags/wkdev-sdk-}"
           if [ "${TAG_VERSION}" != "${VERSION}" ]; then
             echo "Error: git tag wkdev-sdk-${TAG_VERSION} does not match Containerfile WKDEV_SDK_VERSION=${VERSION}"
             exit 1
           fi
+        elif [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+          if [ -z "${PR_HEAD_SHA}" ]; then
+            echo "Error: pull_request event without head SHA"
+            exit 1
+          fi
+          read _ MAJOR_MINOR _ _ < <(./scripts/helpers/print-sdk-version --components)
+          VERSION="${MAJOR_MINOR}-v1-${PR_HEAD_SHA:0:7}"
+          REGISTRY_TAG="pr-${PR_NUMBER}-${PR_HEAD_SHA:0:7}"
+        else
+          echo "Error: unsupported event ${GITHUB_EVENT_NAME} on ref ${GITHUB_REF}"
+          exit 1
         fi
+
+        echo "registry_tag=${REGISTRY_TAG}" >> $GITHUB_OUTPUT
+
+        # VERSION is what's baked into the image as WKDEV_SDK_VERSION (must satisfy
+        # WKDEV_SDK_VERSION_RE so in-container tooling treats it as a real version).
+        # REGISTRY_TAG is the local + registry tag; for PR builds it uses the pr-*
+        # form, which wkdev-create --version accepts via WKDEV_SDK_PR_TAG_RE.
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+        echo "REGISTRY_TAG=${REGISTRY_TAG}" >> $GITHUB_ENV
+        echo "IMAGE_WITH_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${IMAGE_NAME}:${REGISTRY_TAG}" >> $GITHUB_ENV
 
     - name: Build image
       run: |
@@ -60,13 +89,15 @@ jobs:
         CONTAINER="wkdev-$(date +%s)"
         echo "CONTAINER=${CONTAINER}" >> $GITHUB_ENV
         source ./register-sdk-on-host.sh
-        wkdev-create --create-home --home ${HOME}/${CONTAINER}-home --verbose --attach --no-pull --name ${CONTAINER} --arch ${{ matrix.arch }}
+        wkdev-create --create-home --home ${HOME}/${CONTAINER}-home --verbose --attach --no-pull --name ${CONTAINER} --arch ${{ matrix.arch }} --version "${{ env.REGISTRY_TAG }}"
         wkdev-enter -n ${CONTAINER} --exec -- git clone --depth=1 https://github.com/WebKit/WebKit.git
         wkdev-enter -n ${CONTAINER} --exec -- ./WebKit/Tools/Scripts/build-webkit --wpe --release --generate-project-only
         wkdev-enter -n ${CONTAINER} --exec -- ./WebKit/Tools/Scripts/build-webkit --gtk --release --generate-project-only
 
     - name: Push image
-      if: startsWith(github.ref, 'refs/tags/wkdev-sdk-')
+      if: |
+        startsWith(github.ref, 'refs/tags/wkdev-sdk-') ||
+        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
       run: podman push ${{ env.IMAGE_WITH_TAG }}_${{ matrix.arch }}
 
     - name: Clean up test artifacts
@@ -79,28 +110,31 @@ jobs:
         # Clean up any leftover containers and home directories from previous failed runs
         podman ps -a --filter "name=^wkdev-" --format "{{.Names}}" | xargs -r podman rm --force 2>/dev/null || true
         find ${HOME} -maxdepth 1 -type d -name "wkdev-*-home" -exec rm -rf {} + 2>/dev/null || true
+        # Reclaim the freshly built image; per-PR-commit cadence would otherwise grow
+        # the self-hosted runner's image store without bound.
+        podman rmi --force ${{ env.IMAGE_WITH_TAG }}_${{ matrix.arch }} 2>/dev/null || true
 
   deploy:
     runs-on: [self-hosted, x64]
     needs: [build]
-    if: startsWith(github.ref, 'refs/tags/wkdev-sdk-')
+    if: |
+      startsWith(github.ref, 'refs/tags/wkdev-sdk-') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       contents: read
       packages: write
+      pull-requests: write
+    env:
+      REGISTRY_TAG: ${{ needs.build.outputs.registry_tag }}
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
     - name: Log in to GitHub Container Registry
       run: echo "${{ secrets.GITHUB_TOKEN }}" | skopeo login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
-    - name: Resolve version & registry coordinates
+    - name: Resolve registry coordinates
       run: |
-        VERSION="${GITHUB_REF#refs/tags/wkdev-sdk-}"
-        echo "VERSION=${VERSION}" >> $GITHUB_ENV
         echo "GHCR_REPO=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
-        echo "IMAGE_WITH_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/wkdev-sdk:${VERSION}" >> $GITHUB_ENV
+        echo "IMAGE_WITH_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${IMAGE_NAME}:${REGISTRY_TAG}" >> $GITHUB_ENV
 
     - name: Validate all architecture images exist in registry
       id: validate
@@ -127,9 +161,9 @@ jobs:
       uses: bots-house/ghcr-delete-image-action@v1.1.0
       with:
         owner: ${{ env.GHCR_REPO }}
-        name: wkdev-sdk
+        name: ${{ env.IMAGE_NAME }}
         token: ${{ secrets.GITHUB_TOKEN }}
-        tag: ${{ env.VERSION }}_amd64
+        tag: ${{ env.REGISTRY_TAG }}_amd64
 
     - name: Clean up arch-specific images on validation failure (arm64)
       if: failure() && steps.validate.outputs.validation_failed == 'true'
@@ -137,9 +171,9 @@ jobs:
       uses: bots-house/ghcr-delete-image-action@v1.1.0
       with:
         owner: ${{ env.GHCR_REPO }}
-        name: wkdev-sdk
+        name: ${{ env.IMAGE_NAME }}
         token: ${{ secrets.GITHUB_TOKEN }}
-        tag: ${{ env.VERSION }}_arm64
+        tag: ${{ env.REGISTRY_TAG }}_arm64
 
     - name: Pull arch-specific images to local storage
       run: |
@@ -156,17 +190,17 @@ jobs:
       uses: bots-house/ghcr-delete-image-action@v1.1.0
       with:
         owner: ${{ env.GHCR_REPO }}
-        name: wkdev-sdk
+        name: ${{ env.IMAGE_NAME }}
         token: ${{ secrets.GITHUB_TOKEN }}
-        tag: ${{ env.VERSION }}_amd64
+        tag: ${{ env.REGISTRY_TAG }}_amd64
 
     - name: Delete arch-specific tag (arm64)
       uses: bots-house/ghcr-delete-image-action@v1.1.0
       with:
         owner: ${{ env.GHCR_REPO }}
-        name: wkdev-sdk
+        name: ${{ env.IMAGE_NAME }}
         token: ${{ secrets.GITHUB_TOKEN }}
-        tag: ${{ env.VERSION }}_arm64
+        tag: ${{ env.REGISTRY_TAG }}_arm64
 
     - name: Create multi-arch manifest from local storage
       run: |
@@ -183,3 +217,12 @@ jobs:
       run: |
         podman manifest rm ${{ env.IMAGE_WITH_TAG }} 2>/dev/null || true
         podman rmi --force ${{ env.IMAGE_WITH_TAG }}_amd64 ${{ env.IMAGE_WITH_TAG }}_arm64 2>/dev/null || true
+
+    - name: Comment on PR with deployed image
+      if: github.event_name == 'pull_request'
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: wkdev-sdk-pr-image
+        message: |
+          Test image deployed to the registry: `${{ env.IMAGE_WITH_TAG }}`
+          Create a container from it with: `wkdev-create --version ${{ env.REGISTRY_TAG }}`

--- a/.github/workflows/cleanup-wkdev-sdk-pr-tags.yaml
+++ b/.github/workflows/cleanup-wkdev-sdk-pr-tags.yaml
@@ -1,0 +1,51 @@
+name: Clean up wkdev-sdk pr-* image tags on PR close
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete:
+    runs-on: [self-hosted]
+    # Fork PRs are never published (the build/publish workflow excludes them),
+    # so there is nothing to clean up.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      packages: write
+
+    steps:
+    - name: Delete all pr-<N>-* image versions for this PR
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        OWNER: ${{ github.repository_owner }}
+        OWNER_TYPE: ${{ github.event.repository.owner.type }}
+        IMAGE_NAME: wkdev-sdk
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        set -euo pipefail
+        OWNER_LOWER="${OWNER,,}"
+        # The packages API path differs for users vs. orgs.
+        if [ "${OWNER_TYPE}" = "Organization" ]; then
+          base="/orgs/${OWNER_LOWER}/packages/container/${IMAGE_NAME}"
+        elif [ "${OWNER_TYPE}" = "User" ]; then
+          base="/users/${OWNER_LOWER}/packages/container/${IMAGE_NAME}"
+        else
+          echo "Error: unexpected repository owner type '${OWNER_TYPE}'"
+          exit 1
+        fi
+
+        # If the PR closed before the package was ever published, it may not exist.
+        if ! gh api "${base}" >/dev/null 2>&1; then
+          echo "No ${IMAGE_NAME} package found for ${OWNER_LOWER}; nothing to clean up."
+          exit 0
+        fi
+
+        # Releases tags begin with a digit (e.g. 2.53-v5-<sha>); the pr-<N>- prefix
+        # is unambiguous and won't match any release.
+        prefix="pr-${PR_NUMBER}-"
+        ids=$(gh api "${base}/versions" --paginate \
+                --jq ".[] | select((.metadata.container.tags // []) | any(startswith(\"${prefix}\"))) | .id")
+        for id in ${ids}; do
+          echo "Deleting version ${id}"
+          gh api -X DELETE "${base}/versions/${id}" || echo "  warning: failed to delete ${id}"
+        done

--- a/scripts/host-only/wkdev-create
+++ b/scripts/host-only/wkdev-create
@@ -26,7 +26,7 @@ argsparse_use_option rm           "Force removal of container if it already exis
 argsparse_use_option attach       "Attach to container as it starts up."
 argsparse_use_option no-pull      "Do not login or pull images."
 argsparse_use_option list-tags    "List image tags published to the registry."
-argsparse_use_option version:     "Image version (<major>.<minor>, or <major>.<minor>-v<count>-<gitsha>) to use, instead of the version pinned in this checkout. A bare <major>.<minor> resolves to the highest published v<count> for that branch. Pulled from the registry on demand."
+argsparse_use_option version:     "Image version (<major>.<minor>, <major>.<minor>-v<count>-<gitsha>, or pr-<PR-number>-<gitsha>) to use, instead of the version pinned in this checkout. A bare <major>.<minor> resolves to the highest published v<count> for that branch. The pr-* form selects a per-PR build pushed by CI. Pulled from the registry on demand."
 argsparse_use_option =arch:       "Container architecture."
 
 argsparse_usage_description="$(cat <<EOF
@@ -75,8 +75,9 @@ process_command_line_arguments() {
             [ -z "${resolved}" ] && _abort_ "No published image matches version prefix '${container_tag}' in the registry."
             _log_ "-> Resolved --version=${container_tag} to '${resolved}'."
             container_tag="${resolved}"
-        elif [[ ! "${container_tag}" =~ ${WKDEV_SDK_VERSION_PUBLISHED_RE} ]]; then
-            _abort_ "--version must be of the form <major>.<minor> or <major>.<minor>-v<count>-<gitsha> (got '${container_tag}')."
+        elif [[ ! "${container_tag}" =~ ${WKDEV_SDK_VERSION_PUBLISHED_RE} ]] \
+          && [[ ! "${container_tag}" =~ ${WKDEV_SDK_PR_TAG_RE} ]]; then
+            _abort_ "--version must be of the form <major>.<minor>, <major>.<minor>-v<count>-<gitsha>, or pr-<PR-number>-<gitsha> (got '${container_tag}')."
         fi
     else
         container_tag="$(get_default_container_tag)"

--- a/utilities/settings.sh
+++ b/utilities/settings.sh
@@ -30,9 +30,14 @@ get_default_container_registry_user_name() { echo "${WKDEV_SDK_CONTAINER_REGISTR
 #   _PUBLISHED_RE    accepts only fully-stamped <major>.<minor>-v<count>-<gitsha>
 #                    (every image actually published to the registry has a sha).
 #   _MAJOR_MINOR_RE  accepts the bare <major>.<minor> branch prefix.
+#   _PR_TAG_RE       accepts the per-PR build tag pr-<PR-number>-<gitsha>. PR tags
+#                    are deliberately *not* matched by _RE / _PUBLISHED_RE so they
+#                    never appear in release-version listings or comparisons; the
+#                    only place they're accepted is wkdev-create --version.
 readonly WKDEV_SDK_VERSION_RE='^[0-9]+\.[0-9]+-v[0-9]+(-[0-9a-f]+)?$'
 readonly WKDEV_SDK_VERSION_PUBLISHED_RE='^[0-9]+\.[0-9]+-v[0-9]+-[0-9a-f]+$'
 readonly WKDEV_SDK_MAJOR_MINOR_RE='^[0-9]+\.[0-9]+$'
+readonly WKDEV_SDK_PR_TAG_RE='^pr-[0-9]+-[0-9a-f]+$'
 
 # Read from /etc/wkdev-sdk-version inside the container, ARG WKDEV_SDK_VERSION in the
 # Containerfile on the host. Intentionally no env-var/CLI override: every image used by


### PR DESCRIPTION
For PR branches the build/deploy pipeline now publishes a multi-arch image to ghcr.io/<owner>/wkdev-sdk tagged pr-<N>-<sha> -- coexisting with release tags (e.g. 2.53-v5-<sha>) in the same place, distinguished solely by the pr- prefix. The tag is immutable per push (no overwrites, no moving aliases), so every push gets its own pullable handle.

To make pr-tagged images launchable with the standard tooling, the `wkdev-create --version <abc>` validation now also accepts the pr-<N>-<sha> form. The regex for matching that is intentionally disjoint from WKDEV_SDK_VERSION_RE so PR images never leak into release-version listings or comparisons. The image's baked-in WKDEV_SDK_VERSION is still the canonical <MM>-v1-<sha> form, so in-container tooling continues to treat the image as a real SDK version.

On PR close/merge, .github/workflows/cleanup-wkdev-sdk-pr-tags.yaml lists all pr-<N>-* versions of the wkdev-sdk package via the GHCR API and deletes them sequentially, using the user/org type from the event payload to pick the right packages API path.

A sticky PR comment advertises the latest image and pull command. Fork PRs are excluded since their GITHUB_TOKEN lacks packages:write.