### PR TITLE
Document podman as host prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,29 @@ and compile using `./Tools/Scripts/build-webkit [--gtk|--wpe]`, as usual.
 There is extra documentation in the [**docs**](https://github.com/Igalia/webkit-container-sdk/tree/main/docs)
 subdirectory for further information the SDK provides but the guide below will cover common usage.
 
+### Prerequisites
+
+The only host-side dependency is [`podman`](https://podman.io). Install it through your distribution's
+package manager before continuing with the Quickstart guide:
+
+| Distribution                | Install command                              |
+|-----------------------------|----------------------------------------------|
+| Fedora                      | `sudo dnf install podman`                    |
+| Debian (sid) / Ubuntu 23.04+| `sudo apt install podman`                    |
+| Arch Linux                  | `sudo pacman -S podman`                      |
+| openSUSE Tumbleweed         | `sudo zypper install podman`                 |
+
+Verify the installation by running:
+
+```sh
+podman --version
+podman run --rm hello-world
+```
+
+If both commands succeed, `podman` is ready to use and you can move on to the Quickstart guide.
+Refer to [docs/00-Introduction.md](docs/00-Introduction.md) for further background and notes on
+running the SDK rootless.
+
 ### Quickstart guide
 
 1. Integrate the SDK with your shell environment.

--- a/docs/00-Introduction.md
+++ b/docs/00-Introduction.md
@@ -37,13 +37,30 @@ development.
 
 ### Setup procedure
 
-On your **host system** ensure that **podman** is installed.
+On your **host system** the only required dependency is [**podman**](https://podman.io).
+Install it via your distribution's package manager:
 
-* [podman](https://podman.io)
-  * Fedora: [podman](https://packages.fedoraproject.org/pkgs/podman/podman)
-  * Debian (sid): [podman](https://packages.debian.org/sid/podman)
-  * Ubuntu (starting from 23.04): [podman](https://packages.ubuntu.com/lunar/podman)
-  * macOS: [podman](https://formulae.brew.sh/formula/podman)
+* Fedora: `sudo dnf install podman` ([package](https://packages.fedoraproject.org/pkgs/podman/podman))
+* Debian (sid): `sudo apt install podman` ([package](https://packages.debian.org/sid/podman))
+* Ubuntu (starting from 23.04): `sudo apt install podman` ([package](https://packages.ubuntu.com/lunar/podman))
+* Arch Linux: `sudo pacman -S podman`
+* openSUSE Tumbleweed: `sudo zypper install podman`
+
+The SDK is regularly tested with **podman 4.x** and **5.x**. Older versions may work but
+are not actively supported.
+
+Verify the installation by running:
+
+```sh
+podman --version
+podman run --rm hello-world
+```
+
+The second command pulls a tiny test image and runs it to confirm that **rootless** container
+execution is functional on your system. If it fails, consult the
+[podman rootless setup guide](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md)
+-- typical fixes involve ensuring that `/etc/subuid` and `/etc/subgid` contain entries for your
+user and that the `fuse-overlayfs` package is installed.
 
 That's all you need to install on your host system. Now it's the time to get a fresh WebKit source
 checkout, or update/clean an existing one.

--- a/docs/00-Introduction.md
+++ b/docs/00-Introduction.md
@@ -46,8 +46,7 @@ Install it via your distribution's package manager:
 * Arch Linux: `sudo pacman -S podman`
 * openSUSE Tumbleweed: `sudo zypper install podman`
 
-The SDK is regularly tested with **podman 4.x** and **5.x**. Older versions may work but
-are not actively supported.
+The SDK is regularly tested with **podman 4.x** and **5.x**. Older versions are not supported.
 
 Verify the installation by running:
 


### PR DESCRIPTION
The README jumped straight to the Quickstart without naming podman as a host dependency, leaving newcomers to discover the requirement only after wkdev-create failed. Add a Prerequisites section to the README with per-distribution install commands and a quick verification step, and expand the corresponding section in docs/00-Introduction.md with version expectations and a pointer to the rootless setup guide.

Hopefully fixes #232.