### PR TITLE
Add CODEOWNERS for default PR reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default reviewers for any change in this repository.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @TingPing @aperezdc @nikolaszimmermann @clopez


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` so every PR is auto-assigned a default set of reviewers, fixing the long no-feedback gaps reported in the issue.
- Reviewers listed are the maintainer (@TingPing) plus the members who volunteered in the issue thread (@aperezdc, @nikolaszimmermann) and @clopez.

Closes #99

## Test plan
- [ ] Confirm GitHub recognizes the file under Settings -> Code owners / on the PR's "Reviewers" sidebar.
- [ ] Open a follow-up PR (or check this one) and confirm the listed users are auto-requested as reviewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)