### PR TITLE
Add CODEOWNERS for default PR reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default reviewers for any change in this repository.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @TingPing @aperezdc @nikolaszimmermann @clopez


### PR DESCRIPTION
Without code owners, PRs from non-members do not get reviewers assigned automatically and can sit untouched for long stretches. List the maintainer and members who volunteered in the issue thread so every PR gets a default set of reviewers.

Fixes #99.