### PR TITLE
wkdev-sdk: Maintain our own list of WebKit deps

### DIFF
--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -67,11 +67,6 @@ COPY /required_system_packages/*.lst .
 # We unconditionally install the GCC-based cross toolchain for armhf.
 COPY /cross .
 
-# WebKit commit to be used for running Tools/{gtk,wpe}/install-dependencies
-# Update this commit to run the new versions of the install-dependencies scripts.
-# Note: we are explicit with the commit rather than using "main" so the
-# image is reproducible and issues are more easy to bisect.
-ARG WEBKIT_COMMIT=e6ef72584f2d1153f9d9e51af2f87f5ffc2a8712
 # NB: The armhf binary packages can only be found in ports.ubuntu.com. On
 # aarch64, things are already set up properly (aarch64 also uses
 # ports.ubuntu.com and specifies the architecture). However, on x86_64 the
@@ -94,16 +89,6 @@ RUN sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.s
     done; \
     ${APT_BUILDDEP} gst-libav1.0 gst-plugins-bad1.0 gst-plugins-base1.0 \
 	                gst-plugins-good1.0 gst-plugins-ugly1.0 && \
-    git init WebKit && cd WebKit && \
-    git remote add origin https://github.com/WebKit/WebKit.git && \
-    git sparse-checkout init && \
-    git sparse-checkout set Tools && \
-    git fetch --filter=blob:none --depth=1 origin ${WEBKIT_COMMIT} && \
-    git checkout FETCH_HEAD && \
-    yes | ./Tools/gtk/install-dependencies && \
-    yes | ./Tools/wpe/install-dependencies && \
-    cd .. && \
-    rm -rf WebKit && \
     ${APT_AUTOREMOVE} && \
     ${APT_CLEAN} && ${APT_RM_CACHES}
 

--- a/images/wkdev_sdk/required_system_packages/05-jhbuild.lst
+++ b/images/wkdev_sdk/required_system_packages/05-jhbuild.lst
@@ -8,7 +8,7 @@ sysprof libsysprof-6-dev libsysprof-capture-4-dev libpanel-dev
 monado-service monado-cli libopenxr1-monado
 
 # For GStreamer
-libdav1d-dev libopenh264-dev
+libdav1d-dev libopenh264-dev flex bison
 
 # For Epiphany
 gcr4 libgcr-4-dev

--- a/images/wkdev_sdk/required_system_packages/08-webkit.lst
+++ b/images/wkdev_sdk/required_system_packages/08-webkit.lst
@@ -1,0 +1,31 @@
+# Common
+unifdef libharfbuzz-dev libicu-dev libsoup-3.0-dev libepoxy-dev libjxl-dev libxml2-dev
+libmanette-0.2-dev libwoff-dev libgcrypt20-dev zlib1g-dev liblcms2-dev flite1-dev gi-docgen
+libavif-dev libudev-dev libseccomp-dev libwebp-dev
+
+# WPE
+libatk-bridge2.0-dev libcairo2-dev libgbm-dev libdrm-dev libinput-dev
+qt6-declarative-private-dev wayland-protocols
+
+# WebKitGTK
+libgl1-mesa-dev libgtk-3-dev libpango1.0-dev libsecret-1-dev libgtk-4-dev
+
+# For tests
+apache2 binutils fonts-liberation hyphen-de hyphen-en-gb hyphen-en-us libcgi-pm-perl
+psmisc python3-legacy-cgi pulseaudio-utils python3-gi ruby-highline ruby-json time
+cups-daemon dbus-x11 hunspell hunspell-en-gb hunspell-en-us weston xvfb python3-psutil
+
+# Icon themes
+adwaita-icon-theme gnome-icon-theme hicolor-icon-theme
+
+# Cog
+libxcb-cursor-dev libportal-dev libportal-gtk4-dev
+
+# These are dependencies necessary for using webkit-patch.
+git-svn subversion
+
+# These are dependencies necessary for using git-webkit.
+python3-dev
+
+# These are for generate-bundle script
+patchelf p11-kit


### PR DESCRIPTION
While it's a clever idea to try and maintain one list of deps it simply doesn't reflect our usage here. It contains a large amount of things like the entire GStreamer stack and build only deps for the in-tree JHBuild modules. We don't need any of this.