### PR TITLE
wkdev-sdk: Move the WKDEV_SDK_VERSION ARG to preserve the build cache

### DIFF
--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -3,17 +3,8 @@
 
 FROM public.ecr.aws/ubuntu/ubuntu:26.04
 
-# Single source of truth for the SDK version. The release workflow bumps the
-# -v<count> component and appends the source-repo -<gitsha>; everything else
-# (OCI label, /etc/wkdev-sdk-version, welcome message) reads from here.
-# The <major>.<minor> prefix tracks the upstream WebKitGTK / WPE WebKit release
-# branch and is bumped by hand here when moving to a new branch.
-ARG WKDEV_SDK_VERSION=2.53-v9-c666b76
-
-# Tweakable "make -j <x>" setting.
-ARG NUMBER_OF_PARALLEL_BUILDS=4
+# To change WKDEV_SDK_VERSION ARG variable check the bottom of this file.
 ARG CONTAINER_LOCALE=en_US.UTF-8
-
 # No need to modify these.
 ARG APT_UPDATE="apt-get update"
 ARG APT_BUILDDEP="apt-get --assume-yes build-dep"
@@ -235,10 +226,23 @@ ENV WEBKIT_BUILD_USE_SYSTEM_LIBRARIES "1"
 ENV DEBIAN_FRONTEND dialog
 
 LABEL maintainer="webkit-gtk@lists.webkit.org"
-LABEL org.opencontainers.image.version=${WKDEV_SDK_VERSION}
 LABEL org.opencontainers.image.title="WebKit SDK (based on Ubuntu 26.04)"
 LABEL org.opencontainers.image.description="Provides a complete WebKit Gtk/WPE development environment based on Ubuntu 26.04"
 LABEL org.opencontainers.image.source=https://github.com/Igalia/webkit-container-sdk
+
+
+# Single source of truth for the SDK version. The release workflow bumps the
+# -v<count> component and appends the source-repo -<gitsha>; everything else
+# (OCI label, /etc/wkdev-sdk-version, welcome message) reads from here.
+# The <major>.<minor> prefix tracks the upstream WebKitGTK / WPE WebKit release
+# branch and is bumped by hand here when moving to a new branch.
+# IMPORTANT: Keep this at the bottom. Podman passes every ARG to later RUN
+# commands through their environment, even when the command does not use it
+# directly. Therefore, changing the version would prevent Podman from reusing
+# the cache for all later RUN commands. See:
+# https://docs.docker.com/reference/dockerfile/#impact-on-build-caching
+ARG WKDEV_SDK_VERSION=2.53-v9-c666b76
+LABEL org.opencontainers.image.version=${WKDEV_SDK_VERSION}
 
 # Bake the version into the image so the running container can introspect it
 # (welcome message, etc.) without needing access to OCI labels.


### PR DESCRIPTION
Podman makes each `ARG` available in the environment of every later `RUN` command. This meant that changing `WKDEV_SDK_VERSION` invalidated almost all cached layers, even though the version is only needed in the final label and version file.

Move the argument next to those uses at the bottom of the `Containerfile`.

This allows nightly and PR builds to share the expensive build layers.

This behavior can be reproduced with:

```
$ cat > Containerfile <<EOF
FROM ubuntu
ARG BUILD_MODE
RUN env | grep BUILD_MODE
EOF

$ podman build --build-arg BUILD_MODE=MagicValue01 .
[...]
STEP 3/3: RUN env | grep BUILD_MODE
BUILD_MODE=MagicValue01

$ podman build --build-arg BUILD_MODE=MagicValue02 .
[...]
STEP 3/3: RUN env | grep BUILD_MODE
BUILD_MODE=MagicValue02
```

See also:
https://docs.docker.com/reference/dockerfile/#impact-on-build-caching

Meanwhile at it remove also `ARG` `NUMBER_OF_PARALLEL_BUILDS` that was introduced on 9bcf627a but it is not not used anymore.