### PR TITLE
Remove some unused and problematic gstreamer modules

### DIFF
--- a/images/wkdev_sdk/jhbuild/gstreamer.modules
+++ b/images/wkdev_sdk/jhbuild/gstreamer.modules
@@ -28,7 +28,7 @@
     </dependencies>
   </meson>
 
-  <meson id="gstreamer" mesonargs="-Dlibnice=disabled -Dpython=disabled -Dintrospection=disabled -Dgst-plugins-bad:microdns=disabled -Dgst-plugins-bad:avtp=disabled -Dgst-examples=disabled -Dexamples=disabled -Dtests=disabled -Ddoc=disabled -Dgtk_doc=disabled -Dwebrtc=enabled -Dgst-plugins-ugly:gpl=enabled -Dgst-plugins-bad:gpl=enabled -Dgpl=enabled -Dges=disabled -Drtsp_server=disabled -Dqt5=disabled -Dqt6=disabled">
+  <meson id="gstreamer" mesonargs="-Dlibnice=disabled -Dpython=disabled -Dintrospection=disabled -Dgst-plugins-bad:microdns=disabled -Dgst-plugins-bad:avtp=disabled -Dgst-examples=disabled -Dexamples=disabled -Dtests=disabled -Ddoc=disabled -Dgtk_doc=disabled -Dwebrtc=enabled -Dgst-plugins-ugly:gpl=enabled -Dgst-plugins-bad:gpl=enabled -Dgpl=enabled -Dges=disabled -Drtsp_server=disabled -Dqt5=disabled -Dqt6=disabled -Dptp-helper=disabled">
     <branch repo="freedesktop.org"
             checkoutdir="gstreamer"
             module="gstreamer/gstreamer.git"

--- a/images/wkdev_sdk/jhbuild/gstreamer.modules
+++ b/images/wkdev_sdk/jhbuild/gstreamer.modules
@@ -28,7 +28,7 @@
     </dependencies>
   </meson>
 
-  <meson id="gstreamer" mesonargs="-Dlibnice=disabled -Dpython=disabled -Dintrospection=disabled -Dgst-plugins-bad:microdns=disabled -Dgst-plugins-bad:avtp=disabled -Dgst-examples=disabled -Dexamples=disabled -Dtests=disabled -Ddoc=disabled -Dgtk_doc=disabled -Dwebrtc=enabled -Dgst-plugins-ugly:gpl=enabled -Dgst-plugins-bad:gpl=enabled -Dgpl=enabled -Dges=disabled -Drtsp_server=disabled -Dqt5=disabled -Dqt6=disabled -Dptp-helper=disabled">
+  <meson id="gstreamer" mesonargs="-Dlibnice=disabled -Dpython=disabled -Dintrospection=disabled -Dgst-plugins-bad:microdns=disabled -Dgst-plugins-bad:avtp=disabled -Dgst-examples=disabled -Dexamples=disabled -Dtests=disabled -Ddoc=disabled -Dgtk_doc=disabled -Dwebrtc=enabled -Dgst-plugins-ugly:gpl=enabled -Dgst-plugins-bad:gpl=enabled -Dgpl=enabled -Dges=disabled -Drtsp_server=disabled -Dqt5=disabled -Dqt6=disabled -Dptp-helper=disabled -Dvmaf=disabled">
     <branch repo="freedesktop.org"
             checkoutdir="gstreamer"
             module="gstreamer/gstreamer.git"


### PR DESCRIPTION
ptp-helper expects being installed as root which errors with `jhbuild make`

libvmaf is built as an automatic submodule in CI, but `jhbuild make` wasn't building it. Either way it doesn't appear to be used.