### PR TITLE
CI: Add daily podman storage maintenance for self-hosted runners

### DIFF
--- a/.github/scripts/assert-runner-in-maintenance-matrix.sh
+++ b/.github/scripts/assert-runner-in-maintenance-matrix.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Fails (exit 1) when the runner executing this job is not listed in the
+# podman-storage-maintenance.yaml matrix. The matrix entries are runner
+# names (used as unique labels), so a runner missing from that list never
+# gets its storage reset and would silently fill up its disk.
+#
+# Expects RUNNER_NAME in the environment (the workflow passes runner.name).
+# The match is an exact whole-string comparison against every `runner:` value
+# of the matrix, so a runner name is never treated as a pattern (no false
+# match) and quoted entries, names containing spaces or a trailing comment on
+# the matrix line are all handled (no false "not covered" failure).
+#
+# Exits 2 when the matrix itself cannot be read: no entries at all, a
+# flow-style entry ({arch: ..., runner: ...}), or an entry this script
+# cannot parse (unclosed quote, a comment-like '#' inside a quoted name, or
+# a quote character anywhere in a name). Those get their own error, because
+# "I cannot tell" and "this runner is not covered" call for different fixes.
+
+set -euo pipefail
+
+RUNNER_NAME="${RUNNER_NAME:?RUNNER_NAME must be set to runner.name}"
+MAINTENANCE_WORKFLOW=".github/workflows/podman-storage-maintenance.yaml"
+
+if [[ ! -f "$MAINTENANCE_WORKFLOW" ]]; then
+  echo "error: ${MAINTENANCE_WORKFLOW} not found (not running from the repository root?): cannot audit" >&2
+  exit 2
+fi
+
+# Limit all parsing to the matrix of the maintenance job. A `runner:` key in
+# another job must never make this audit claim that the machine is covered.
+job_block=$(sed -n '/^  system-reset-and-rebuild:/,/^  [^ ]/p' "$MAINTENANCE_WORKFLOW")
+matrix_block=$(sed -n '/^      matrix:/,/^    [^ ]/p' <<<"$job_block")
+
+# A flow-style entry ({arch: ..., runner: ...}) is invisible to the
+# extraction below, so its runner would be reported as "not covered" even
+# though the maintenance job does reach it. Refuse to answer instead.
+flow_entries=$(sed -n -e '/^[[:space:]]*#/d' \
+                      -e '/{[^}]*runner[[:space:]]*:/{s/^[[:space:]]*//p}' \
+                      <<<"$matrix_block")
+if [[ -n "$flow_entries" ]]; then
+  echo "::error title=Unparseable runner entry in the maintenance matrix::Cannot read these flow-style entries of ${MAINTENANCE_WORKFLOW}: ${flow_entries//$'\n'/, }. Write each matrix entry in block form, with 'runner: <name>' on its own line."
+  exit 2
+fi
+
+# Every `runner:` value of the matrix, one per line: commented-out entries are
+# ignored, then each value has its trailing comment, trailing whitespace and
+# surrounding quotes removed.
+covered_runners=$(
+  sed -n -e '/^[[:space:]]*#/d' \
+         -e 's/^[[:space:]]*-\{0,1\}[[:space:]]*runner[[:space:]]*:[[:space:]]*//p' \
+         <<<"$matrix_block" \
+    | sed -e 's/[[:space:]][[:space:]]*#.*$//' -e 's/[[:space:]]*$//' \
+          -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/"
+)
+
+if [[ -z "$covered_runners" ]]; then
+  echo "::error title=No runner entries in the maintenance matrix::${MAINTENANCE_WORKFLOW} has no 'runner:' entry, so this audit cannot tell whether this machine is covered."
+  exit 2
+fi
+
+# A value that still carries a quote was not parsed as intended: an unclosed
+# quote, a whitespace-prefixed '#' inside a quoted name (taken for a trailing
+# comment above), or a quote character that is part of the name itself.
+# Report that instead of answering the coverage question wrongly.
+if unparseable=$(grep -F -e '"' -e "'" <<<"$covered_runners"); then
+  echo "::error title=Unparseable runner entry in the maintenance matrix::Cannot read these runner entries of ${MAINTENANCE_WORKFLOW}: ${unparseable//$'\n'/, }. Write each one as a plain or fully quoted scalar, without a whitespace-prefixed '#' inside the name."
+  exit 2
+fi
+
+# -x -F: whole-line literal match, so no character of the name is special.
+# -e: a name starting with '-' must not be taken for a grep option.
+if grep -qxF -e "$RUNNER_NAME" <<<"$covered_runners"; then
+  echo "Runner '${RUNNER_NAME}' is covered by the storage maintenance workflow."
+else
+  echo "::error title=Runner not covered by storage maintenance::Runner '${RUNNER_NAME}' is not listed in the ${MAINTENANCE_WORKFLOW} matrix, so its storage is never reset. Add the runner's name as a label to it in the GitHub UI and add a matrix entry."
+  exit 1
+fi

--- a/.github/scripts/build-wkdev-sdk-image.sh
+++ b/.github/scripts/build-wkdev-sdk-image.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Single source of truth for building the wkdev-sdk image. Used by the image
+# build workflow and by the storage maintenance cache-warming rebuild: both
+# MUST build the exact same way, otherwise the layers produced by the nightly
+# rebuild would not be reusable as cache by the PR builds.
+
+set -euo pipefail
+
+VERSION="${1:?Usage: $0 <wkdev-sdk-version> <image-tag> <arch>}"
+TAG="${2:?Usage: $0 <wkdev-sdk-version> <image-tag> <arch>}"
+ARCH="${3:?Usage: $0 <wkdev-sdk-version> <image-tag> <arch>}"
+
+podman build --jobs "$(nproc)" --build-context scripts=./scripts \
+  --build-arg WKDEV_SDK_VERSION="${VERSION}" \
+  -t "${TAG}" --arch="${ARCH}" images/wkdev_sdk
+podman image list

--- a/.github/scripts/disk-usage.sh
+++ b/.github/scripts/disk-usage.sh
@@ -1,0 +1,330 @@
+#!/bin/bash
+# Disk usage helper for the podman storage maintenance workflow.
+#
+# Usage:
+#   disk-usage.sh snapshot <output-file> <label>
+#   disk-usage.sh compare  <beforereset.txt> <afterreset.txt> <afterbuild.txt>
+#   disk-usage.sh check    [min-free-gb]
+#
+# `snapshot` captures filesystem + podman storage usage to <output-file>,
+# emitting both machine-readable KEY=VALUE lines and a human-readable
+# section in one go (df and du are each run only once). It always deletes a
+# pre-existing <output-file> first, so a failed run can never leave a stale
+# snapshot behind: when it fails, no file is written at all. If only the
+# optional du measurement of the graphroot fails, the snapshot is still
+# written (and succeeds) with PODMAN_SIZE=unknown.
+#
+# `compare` reads three snapshot files and prints the freed-space /
+# build-cost summary. Also writes a markdown table to $GITHUB_STEP_SUMMARY
+# when present. If any of the three files is missing or has unexpected
+# content, the comparison is skipped with a note explaining why. A snapshot
+# with PODMAN_SIZE=unknown is still accepted: the filesystem metrics are
+# reported normally and only the affected podman storage deltas degrade to
+# "not measured".
+#
+# `check` reports whether the free space on the podman graphroot filesystem
+# is at least <min-free-gb> GiB (default: ${DEFAULT_MIN_FREE_GB}). This is the
+# single source of truth for the low-disk threshold the maintenance workflow
+# uses to decide whether a reset is actually needed.
+#
+# Exit status convention (all actions): 0 = did what was asked; 1 =
+# meaningful negative result (check: disk below threshold); 2 = could not
+# operate (podman broken, snapshot files missing or invalid, bad argument).
+# The script always reports failure honestly; callers decide where a
+# non-zero status is tolerable.
+
+set -euo pipefail
+
+DEFAULT_MIN_FREE_GB=50
+
+# Format a byte count as human-readable, preserving sign. Falls back to raw bytes if numfmt isn't available.
+human() {
+  local n="$1"
+  local sign=""
+  if [[ "$n" =~ ^- ]]; then
+    sign="-"
+    n="${n#-}"
+  fi
+  if [[ ! "$n" =~ ^[0-9]+$ ]]; then
+    # Not a byte count (e.g. "unknown"): pass it through untouched.
+    echo "$1"
+    return
+  fi
+  if command -v numfmt >/dev/null 2>&1; then
+    echo "${sign}$(numfmt --to=iec-i --suffix=B --format='%.2f' "$n")"
+  else
+    echo "${sign}${n} bytes"
+  fi
+}
+
+# Render a byte count, or "not measured" when it is not a number (a snapshot
+# recorded PODMAN_SIZE=unknown). Same wording as delta() below, so a report
+# never mixes vocabularies for the same gap.
+size() {
+  if [[ "$1" =~ ^[0-9]+$ ]]; then
+    human "$1"
+  else
+    echo "not measured"
+  fi
+}
+
+# Subtract two byte counts ($1 - $2) and render the result. Prints "not
+# measured" when either operand is not a number, so the caller reports an
+# honest gap instead of a fabricated delta. Deltas degrade one by one: a
+# delta between two measured snapshots is still a real number even when a
+# third snapshot could not be measured.
+delta() {
+  if [[ "$1" =~ ^[0-9]+$ && "$2" =~ ^[0-9]+$ ]]; then
+    human "$(( $1 - $2 ))"
+  else
+    echo "not measured"
+  fi
+}
+
+# Return VALUE from a KEY=VALUE entry from a snapshot file.
+get_val() {
+  grep -E "^$2=" "$1" | head -1 | cut -d= -f2-
+}
+
+graphroot() {
+  podman info --format '{{.Store.GraphRoot}}'
+}
+
+action_snapshot() {
+  local OUT="${1:?Usage: $0 snapshot <output-file> <label>}"
+  local LABEL="${2:?Usage: $0 snapshot <output-file> <label>}"
+
+  # Never leave a file from a previous run behind: if this run can't produce
+  # a snapshot, compare must find a missing file, not stale data.
+  rm -f "$OUT" "$OUT.tmp"
+
+  local GRAPHROOT
+  if ! GRAPHROOT="$(graphroot)"; then
+    echo "warning: podman is not functional (podman info failed): no snapshot taken" >&2
+    return 2
+  fi
+
+  local fs_line FS_SIZE FS_USED FS_AVAIL
+  if ! fs_line=$(df -B1 --output=size,used,avail "$GRAPHROOT" | tail -1); then
+    echo "warning: cannot query the filesystem of $GRAPHROOT: no snapshot taken" >&2
+    return 2
+  fi
+  read -r FS_SIZE FS_USED FS_AVAIL <<<"$fs_line"
+
+  # For rootless podman the storage contains files owned by subuids, which
+  # plain du can't stat; podman unshare enters the user namespace where they
+  # are readable. Fall back to plain du (rootful podman) if that fails.
+  # Only a du that exited successfully is trusted: a du that failed partway
+  # (e.g. unreadable subdirectories) still prints a grand total, but that
+  # total is an undercount and must not be recorded as a real measurement.
+  local PODMAN_SIZE="" du_out
+  if du_out=$(podman unshare du -sb "$GRAPHROOT" 2>/dev/null) \
+      || du_out=$(du -sb "$GRAPHROOT" 2>/dev/null); then
+    PODMAN_SIZE=$(awk 'NR==1{print $1}' <<<"$du_out")
+    [[ "$PODMAN_SIZE" =~ ^[0-9]+$ ]] || PODMAN_SIZE=""
+  fi
+  # PODMAN_SIZE is "unknown" (never a fake 0) when neither du method could
+  # fully traverse the graphroot. This deliberately does NOT fail the
+  # snapshot: podman itself may be perfectly healthy and the filesystem
+  # statistics remain useful. The non-numeric value makes compare report the
+  # affected storage deltas as "not measured" instead of fabricating them
+  # from a placeholder.
+  PODMAN_SIZE="${PODMAN_SIZE:-unknown}"
+
+  {
+    echo "=== $LABEL ($(date -u +%Y-%m-%dT%H:%M:%SZ)) ==="
+    echo
+    echo "## Machine-readable (bytes)"
+    echo "FS_SIZE=$FS_SIZE"
+    echo "FS_USED=$FS_USED"
+    echo "FS_AVAIL=$FS_AVAIL"
+    echo "PODMAN_SIZE=$PODMAN_SIZE"
+    echo "GRAPHROOT=$GRAPHROOT"
+    echo
+    echo "## Graphroot filesystem ($GRAPHROOT)"
+    echo "  Size:      $(human "$FS_SIZE")"
+    echo "  Used:      $(human "$FS_USED")"
+    echo "  Available: $(human "$FS_AVAIL")"
+    echo
+    echo "## Podman storage size"
+    echo "  $(human "$PODMAN_SIZE")"
+    echo
+    echo "## df -h (all mounts, for context)"
+    df -h || echo "(df -h failed; an unrelated mount may be dead)"
+    echo
+    echo "## podman system df"
+    podman system df || echo "(podman system df failed)"
+    echo
+    echo "## podman system df -v"
+    podman system df -v || echo "(podman system df -v failed)"
+    echo
+  } | tee "$OUT.tmp"
+  # Publish the snapshot only once it is complete: whatever fails mid-block
+  # above must never leave a partial file that compare would accept as valid.
+  mv "$OUT.tmp" "$OUT"
+}
+
+action_compare() {
+  local BEFORERESET="${1:?Usage: $0 compare <beforereset> <afterreset> <afterbuild>}"
+  local AFTERRESET="${2:?Usage: $0 compare <beforereset> <afterreset> <afterbuild>}"
+  local AFTERBUILD="${3:?Usage: $0 compare <beforereset> <afterreset> <afterbuild>}"
+
+  # A snapshot may legitimately not exist (snapshot writes no file when
+  # podman is broken). Refuse to compare against missing or unexpected
+  # content instead of failing cryptically or producing garbage numbers.
+  local f
+  for f in "$BEFORERESET" "$AFTERRESET" "$AFTERBUILD"; do
+    if [[ ! -f "$f" ]] \
+        || [[ "$(grep -cE '^FS_AVAIL=[0-9]+$' "$f")" -ne 1 ]] \
+        || [[ "$(grep -cE '^PODMAN_SIZE=([0-9]+|unknown)$' "$f")" -ne 1 ]]; then
+      echo "warning: snapshot '$f' is missing or incomplete (was podman broken when it should have been taken?): skipping comparison"
+      if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        echo "Comparison skipped: snapshot \`$f\` is missing or incomplete." >> "$GITHUB_STEP_SUMMARY"
+      fi
+      return 2
+    fi
+  done
+
+  local B_RESET_AVAIL A_RESET_AVAIL A_BUILD_AVAIL B_RESET_PODMAN A_RESET_PODMAN A_BUILD_PODMAN
+  B_RESET_AVAIL=$(get_val "$BEFORERESET" FS_AVAIL)
+  A_RESET_AVAIL=$(get_val "$AFTERRESET"  FS_AVAIL)
+  A_BUILD_AVAIL=$(get_val "$AFTERBUILD"  FS_AVAIL)
+  B_RESET_PODMAN=$(get_val "$BEFORERESET" PODMAN_SIZE)
+  A_RESET_PODMAN=$(get_val "$AFTERRESET"  PODMAN_SIZE)
+  A_BUILD_PODMAN=$(get_val "$AFTERBUILD"  PODMAN_SIZE)
+
+  local FREED_BY_CYCLE=$((  A_BUILD_AVAIL  - B_RESET_AVAIL  ))
+  local BUILD_COST=$((      A_RESET_AVAIL  - A_BUILD_AVAIL  ))
+
+  # PODMAN_SIZE may be "unknown" in any snapshot (du could not traverse the
+  # graphroot when it was taken). The filesystem numbers above are still
+  # valid and are the key metrics, so only the deltas touching an unknown
+  # measurement degrade to "not measured".
+  local PODMAN_NET PODMAN_BUILD PODMAN_REMOVED
+  PODMAN_NET=$(delta     "$A_BUILD_PODMAN" "$B_RESET_PODMAN")
+  PODMAN_BUILD=$(delta   "$A_BUILD_PODMAN" "$A_RESET_PODMAN")
+  PODMAN_REMOVED=$(delta "$B_RESET_PODMAN" "$A_RESET_PODMAN")
+  if [[ "${PODMAN_NET}${PODMAN_BUILD}${PODMAN_REMOVED}" == *"not measured"* ]]; then
+    echo "warning: at least one snapshot could not measure the podman storage size: the filesystem numbers below are complete, the affected podman deltas read \"not measured\""
+  fi
+
+  cat <<EOF
+
+============================================================
+            PODMAN STORAGE MAINTENANCE SUMMARY
+============================================================
+
+Filesystem available space:
+  Before reset:  $(human "$B_RESET_AVAIL")
+  After  reset:  $(human "$A_RESET_AVAIL")
+  After  build:  $(human "$A_BUILD_AVAIL")
+
+Podman storage size (graphroot du):
+  Before reset:  $(size "$B_RESET_PODMAN")
+  After  reset:  $(size "$A_RESET_PODMAN")
+  After  build:  $(size "$A_BUILD_PODMAN")
+
+------------------------------------------------------------
+Key metrics
+------------------------------------------------------------
+
+1) Net space freed by this cycle (AfterBuild vs BeforeReset)
+   $(human "$FREED_BY_CYCLE")
+
+2) How much space the freshly built image needs (AfterReset vs AfterBuild)
+   $(human "$BUILD_COST")
+
+------------------------------------------------------------
+Podman storage deltas (for context)
+------------------------------------------------------------
+
+  Removed by reset (BeforeReset - AfterReset):  ${PODMAN_REMOVED}
+  Added by build  (AfterBuild - AfterReset):    ${PODMAN_BUILD}
+  Net change      (AfterBuild - BeforeReset):   ${PODMAN_NET}
+
+============================================================
+EOF
+
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      echo "## Podman storage maintenance summary"
+      echo
+      echo "| Metric | Value |"
+      echo "|---|---|"
+      echo "| Net space freed (AfterBuild - BeforeReset) | $(human "$FREED_BY_CYCLE") |"
+      echo "| Build cost (AfterReset - AfterBuild) | $(human "$BUILD_COST") |"
+      echo "| Removed by reset (BeforeReset - AfterReset) | ${PODMAN_REMOVED} |"
+      echo "| Added by build (AfterBuild - AfterReset) | ${PODMAN_BUILD} |"
+      echo "| Podman storage net change (AfterBuild - BeforeReset) | ${PODMAN_NET} |"
+      echo
+      echo "### Filesystem available"
+      echo "- BeforeReset: \`$(human "$B_RESET_AVAIL")\`"
+      echo "- AfterReset:  \`$(human "$A_RESET_AVAIL")\`"
+      echo "- AfterBuild:  \`$(human "$A_BUILD_AVAIL")\`"
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+action_check() {
+  local MIN_FREE_GB="${1:-$DEFAULT_MIN_FREE_GB}"
+  # Reject a bad threshold with "could not operate" (exit 2) rather than
+  # letting the arithmetic below die on it and exit 1, which callers read as
+  # "disk below threshold". Force base 10 afterwards: bash arithmetic reads
+  # a leading zero ("08") as an invalid octal number and would die the same
+  # wrong way on input the regex accepts.
+  if [[ ! "$MIN_FREE_GB" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: the minimum free space threshold must be a whole number of GiB, got '${MIN_FREE_GB}'"
+    return 2
+  fi
+  MIN_FREE_GB=$(( 10#$MIN_FREE_GB ))
+  local MIN_FREE_BYTES=$(( MIN_FREE_GB * 1024 * 1024 * 1024 ))
+
+  local GRAPHROOT FS_AVAIL
+  if ! GRAPHROOT="$(graphroot)"; then
+    echo "ERROR: podman is not functional (podman info failed): assuming storage maintenance is needed"
+    return 2
+  fi
+  if ! FS_AVAIL=$(df -B1 --output=avail "$GRAPHROOT" | tail -1 | tr -d ' '); then
+    echo "ERROR: cannot query free space on $GRAPHROOT: assuming storage maintenance is needed"
+    return 2
+  fi
+
+  if (( FS_AVAIL >= MIN_FREE_BYTES )); then
+    echo "OK: $(human "$FS_AVAIL") free on $GRAPHROOT (threshold: ${MIN_FREE_GB}GiB)"
+    return 0
+  fi
+  echo "LOW: only $(human "$FS_AVAIL") free on $GRAPHROOT (threshold: ${MIN_FREE_GB}GiB)"
+  return 1
+}
+
+# main
+
+ACTION="${1:-}"
+case "$ACTION" in
+  snapshot)
+    shift
+    action_snapshot "$@"
+    ;;
+  compare)
+    shift
+    action_compare "$@"
+    ;;
+  check)
+    shift
+    action_check "$@"
+    ;;
+  ""|-h|--help|help)
+    cat <<EOF
+Usage:
+  $0 snapshot <output-file> <label>
+  $0 compare  <beforereset.txt> <afterreset.txt> <afterbuild.txt>
+  $0 check    [min-free-gb]   (default: ${DEFAULT_MIN_FREE_GB})
+EOF
+    [[ -z "$ACTION" ]] && exit 1 || exit 0
+    ;;
+  *)
+    echo "Unknown action: $ACTION" >&2
+    echo "Run '$0 --help' for usage." >&2
+    exit 1
+    ;;
+esac

--- a/.github/scripts/tests/test-assert-runner-in-maintenance-matrix.sh
+++ b/.github/scripts/tests/test-assert-runner-in-maintenance-matrix.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# Test harness for .github/scripts/assert-runner-in-maintenance-matrix.sh:
+# exercises every YAML spelling the parser supports, every rejection, and
+# the exit-code contract (0 = covered, 1 = not covered, 2 = cannot tell).
+# Run it directly; it needs no arguments and touches nothing outside a temp
+# directory. It ends by checking the real maintenance matrix of this repo.
+set -u
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/assert-runner-in-maintenance-matrix.sh"
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+
+PASS=0; FAIL=0
+# t <description> <runner-name> <expected-exit-code>
+# The script under test reads .github/workflows/podman-storage-maintenance.yaml
+# relative to the current directory.
+t() {
+  local rc=0 out
+  out=$(RUNNER_NAME="$2" "$SCRIPT" 2>&1) || rc=$?
+  if [ "$rc" = "$3" ]; then PASS=$((PASS+1)); echo "PASS: $1"
+  else FAIL=$((FAIL+1)); echo "FAIL: $1 (exit $rc, wanted $3) :: $out"; fi
+}
+matrix() { # write a matrix with the given entry lines to the temp workdir
+  mkdir -p "$T/work/.github/workflows"
+  printf 'jobs:\n  system-reset-and-rebuild:\n    strategy:\n      matrix:\n        include:\n%s\n    runs-on: self-hosted\n' "$1" \
+    > "$T/work/.github/workflows/podman-storage-maintenance.yaml"
+  cd "$T/work"
+}
+
+echo "=== every supported spelling matches ==="
+matrix '          - arch: amd64
+            runner: plain-1
+          - runner: "quoted-2"
+          - runner: '\''squoted-3'\''
+          - runner: name with spaces 4
+          - runner: commented-5   # rack 3
+          - runner: "quoted-commented-6"   # rack 4
+          - runner: -dash-leading-7
+          - arch: amd64
+            runner : spaced-key-8
+          - runner: plain#hash
+          - runner: "quoted#hash"
+          # - runner: decommissioned-9'
+t "plain entry"                      "plain-1" 0
+t "double-quoted entry"              "quoted-2" 0
+t "single-quoted entry"              "squoted-3" 0
+t "name with spaces"                 "name with spaces 4" 0
+t "trailing comment"                 "commented-5" 0
+t "quoted + trailing comment"        "quoted-commented-6" 0
+t "name starting with a dash"        "-dash-leading-7" 0
+t "space before the colon"           "spaced-key-8" 0
+t "hash in a plain name"             "plain#hash" 0
+t "hash in a quoted name"            "quoted#hash" 0
+
+echo "=== what must NOT match ==="
+t "commented-out entry"              "decommissioned-9" 1
+t "absent name"                      "not-listed" 1
+t "prefix of a listed name"          "plain" 1
+t "superstring of a listed name"     "plain-11" 1
+t "regex metacharacters stay literal" "plain-." 1
+t "quotes are not part of the name"  "\"quoted-2\"" 1
+t "hash suffix is not discarded"     "plain" 1
+
+echo "=== entries outside the maintenance matrix are ignored ==="
+matrix '          - runner: maintenance-10'
+printf '  unrelated-job:\n    strategy:\n      matrix:\n        runner: unrelated-11\n' \
+  >> "$T/work/.github/workflows/podman-storage-maintenance.yaml"
+t "maintenance runner remains covered"  "maintenance-10" 0
+t "runner from another job is not covered" "unrelated-11" 1
+
+echo "=== unreadable matrices are exit 2, never a wrong answer ==="
+matrix '          - runner: "unclosed-12'
+t "unclosed quote"                   "unclosed-12" 2
+matrix '          - runner: "hash # inside 13"'
+t "hash inside a quoted name"        "hash # inside 13" 2
+matrix "          - runner: o'brien-14"
+t "quote character inside a name"    "o'brien-14" 2
+matrix '          - arch: amd64
+            runner: block-15
+          - {arch: arm64, runner: flow-16}'
+t "flow-style entry present: flow name"  "flow-16" 2
+t "flow-style entry present: block name" "block-15" 2
+matrix '          - runner: plain-17
+          # - {arch: amd64, runner: dead-flow-18}'
+t "commented-out flow entry is ignored"  "plain-17" 0
+t "commented-out flow name not covered"  "dead-flow-18" 1
+matrix '          - {arch: amd64, runner: flow-only-19}'
+t "flow-only matrix"                     "flow-only-19" 2
+mkdir -p "$T/work/.github/workflows"
+printf 'jobs:\n  system-reset-and-rebuild:\n    strategy:\n      matrix:\n        include: [{arch: amd64, runner: inline-20}]\n          # a block entry elsewhere must not mask the inline one:\n      other:\n        runner: block-21\n    runs-on: self-hosted\n' \
+  > "$T/work/.github/workflows/podman-storage-maintenance.yaml"
+cd "$T/work"
+t "inline-array flow entry detected"     "inline-20" 2
+matrix '          - arch: amd64'
+t "matrix without runner entries"    "anything" 2
+cd "$T"
+rm -rf "$T/work"
+mkdir -p "$T/work" && cd "$T/work"
+t "workflow file missing"            "anything" 2
+
+echo "=== the real matrix of this repository ==="
+cd "$REPO_ROOT"
+REAL_MATRIX=".github/workflows/podman-storage-maintenance.yaml"
+# The real matrix keeps its entries in the plain `runner: <name>` form, so
+# this trivial awk is a fair independent oracle for what must be covered.
+REAL_RUNNERS=$(awk '$1 == "runner:" {print $2}' "$REAL_MATRIX")
+if [ -z "$REAL_RUNNERS" ]; then
+  FAIL=$((FAIL+1)); echo "FAIL: no plain runner: entries found in $REAL_MATRIX"
+fi
+while IFS= read -r name; do
+  t "real matrix entry: $name" "$name" 0
+done <<<"$REAL_RUNNERS"
+t "name absent from the real matrix" "no-such-runner-anywhere" 1
+
+echo
+echo "================================"
+echo "RESULT: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/.github/scripts/tests/test-disk-usage.sh
+++ b/.github/scripts/tests/test-disk-usage.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+# Test harness for .github/scripts/disk-usage.sh: stubs podman/df/du via PATH
+# and checks every action, exit code and degradation path. Run it directly;
+# it needs no arguments and touches nothing outside a temp directory.
+set -u
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/disk-usage.sh"
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+mkdir -p "$T/bin" "$T/graphroot" "$T/out"
+
+# ---- stubs -------------------------------------------------------------
+# podman stub: modes via PODMAN_MODE (normal | nounshare | broken | brokendf)
+cat > "$T/bin/podman" <<STUB
+#!/bin/bash
+MODE="\${PODMAN_MODE:-normal}"
+case "\$1" in
+  info)
+    [ "\$MODE" = broken ] && { echo "cannot connect to podman" >&2; exit 125; }
+    echo "$T/graphroot"
+    ;;
+  unshare)
+    [ "\$MODE" = nounshare ] && { echo "unshare failed" >&2; exit 1; }
+    shift; exec "\$@"
+    ;;
+  system)
+    [ "\$MODE" = brokendf ] && { echo "storage corrupted" >&2; exit 125; }
+    echo "podman system df stub output"
+    ;;
+  *) echo "unexpected podman args: \$*" >&2; exit 1;;
+esac
+STUB
+# df stub: DF_FAKE_AVAIL overrides avail (bytes); DF_H_FAIL=1 fails `df -h`
+cat > "$T/bin/df" <<'STUB'
+#!/bin/bash
+if [ "${DF_H_FAIL:-}" = 1 ] && [ "$*" = "-h" ]; then echo "df: /deadmount: Transport endpoint is not connected" >&2; exit 1; fi
+if [ -n "${DF_FAKE_AVAIL:-}" ]; then
+  case "$*" in
+    *--output=size,used,avail*) printf '1B-blocks Used Avail\n1000000000000 500000000000 %s\n' "$DF_FAKE_AVAIL"; exit 0;;
+    *--output=avail*) printf 'Avail\n%s\n' "$DF_FAKE_AVAIL"; exit 0;;
+  esac
+fi
+exec /usr/bin/df "$@"
+STUB
+# du stub: DU_FAKE_SIZE overrides, DU_FAIL=1 makes it fail; otherwise real du
+cat > "$T/bin/du" <<'STUB'
+#!/bin/bash
+[ "${DU_FAIL:-}" = 1 ] && { echo "du failed" >&2; exit 1; }
+[ "${DU_PARTIAL:-}" = 1 ] && { echo "du: cannot read directory: Permission denied" >&2; printf '%s\t%s\n' "12345" "${@: -1}"; exit 1; }
+if [ -n "${DU_FAKE_SIZE:-}" ]; then printf '%s\t%s\n' "$DU_FAKE_SIZE" "${@: -1}"; exit 0; fi
+exec /usr/bin/du "$@"
+STUB
+chmod +x "$T/bin/podman" "$T/bin/df" "$T/bin/du"
+export PATH="$T/bin:$PATH"
+
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); echo "PASS: $1"; }
+bad()  { FAIL=$((FAIL+1)); echo "FAIL: $1"; }
+# assert <desc> <expected-exit|NZ> <grep-pattern|-> -- cmd...
+assert() {
+  local desc="$1" want_rc="$2" pat="$3"; shift 3; shift # eat --
+  local out rc
+  out=$("$@" 2>&1); rc=$?
+  if [ "$want_rc" = NZ ]; then
+    [ "$rc" -ne 0 ] || { bad "$desc (exit 0, wanted non-zero) :: $out"; return; }
+  elif [ "$rc" != "$want_rc" ]; then bad "$desc (exit $rc, wanted $want_rc) :: $out"; return; fi
+  if [ "$pat" != "-" ] && ! grep -qE "$pat" <<<"$out"; then bad "$desc (missing /$pat/) :: $out"; return; fi
+  ok "$desc"
+}
+
+GB=$((1024*1024*1024))
+
+echo "=== main dispatch ==="
+assert "no args -> usage, exit 1"            1 "Usage:" -- "$SCRIPT"
+assert "--help -> usage, exit 0"             0 "Usage:" -- "$SCRIPT" --help
+assert "-h -> usage, exit 0"                 0 "Usage:" -- "$SCRIPT" -h
+assert "help -> usage, exit 0"               0 "Usage:" -- "$SCRIPT" help
+assert "unknown action -> error, exit 1"     1 "Unknown action: frobnicate" -- "$SCRIPT" frobnicate
+
+echo "=== check: thresholds and boundaries (stubbed df) ==="
+export DF_FAKE_AVAIL=$((50*GB))
+assert "avail == threshold (50GB) -> OK"     0 "^OK:" -- "$SCRIPT" check
+export DF_FAKE_AVAIL=$((50*GB-1))
+assert "avail == threshold-1 byte -> LOW"    1 "^LOW:" -- "$SCRIPT" check
+export DF_FAKE_AVAIL=$((49*GB))
+assert "explicit threshold 49 -> OK"         0 "^OK:" -- "$SCRIPT" check 49
+assert "explicit threshold 50 -> LOW"        1 "^LOW:" -- "$SCRIPT" check 50
+export DF_FAKE_AVAIL=0
+assert "zero free -> LOW"                    1 "only 0.00B" -- "$SCRIPT" check
+assert "non-numeric threshold -> cannot operate (exit 2)" 2 "must be a whole number" -- "$SCRIPT" check banana
+assert "negative threshold -> cannot operate (exit 2)"    2 "must be a whole number" -- "$SCRIPT" check -5
+assert "empty threshold falls back to the default"        1 "threshold: 50GiB" -- "$SCRIPT" check ""
+assert "threshold 0 is valid (always OK)"                 0 "^OK:" -- "$SCRIPT" check 0
+assert "leading zero read as decimal, not octal (08=8)"   1 "threshold: 8GiB" -- "$SCRIPT" check 08
+assert "all-zeros threshold works (000=0)"                0 "^OK:.*threshold: 0GiB" -- "$SCRIPT" check 000
+unset DF_FAKE_AVAIL
+
+echo "=== snapshot: happy path (stubbed values) ==="
+export DF_FAKE_AVAIL=$((100*GB)) DU_FAKE_SIZE=$((7*GB))
+assert "snapshot runs"                       0 "FS_AVAIL=$((100*GB))" -- "$SCRIPT" snapshot "$T/out/s1.txt" "LABEL-1"
+grep -q "PODMAN_SIZE=$((7*GB))" "$T/out/s1.txt" && ok "snapshot PODMAN_SIZE from podman-unshare du" || bad "snapshot PODMAN_SIZE wrong"
+grep -q "GRAPHROOT=$T/graphroot" "$T/out/s1.txt" && ok "snapshot GRAPHROOT recorded" || bad "snapshot GRAPHROOT wrong"
+grep -q "=== LABEL-1 (....-..-..T..:..:..Z) ===" "$T/out/s1.txt" && ok "snapshot label+timestamp" || bad "snapshot label/timestamp missing"
+for key in FS_SIZE FS_USED FS_AVAIL PODMAN_SIZE; do
+  v=$(grep -E "^$key=" "$T/out/s1.txt" | cut -d= -f2)
+  [[ "$v" =~ ^[0-9]+$ ]] && ok "snapshot $key numeric ($v)" || bad "snapshot $key not numeric: '$v'"
+done
+[ ! -e "$T/out/s1.txt.tmp" ] && ok "no .tmp left after successful snapshot" || bad ".tmp leftover after success"
+printf 'stale tmp junk' > "$T/out/s1.txt.tmp"
+"$SCRIPT" snapshot "$T/out/s1.txt" "LABEL-1b" > /dev/null
+[ ! -e "$T/out/s1.txt.tmp" ] && grep -q "LABEL-1b" "$T/out/s1.txt" && ok "stale .tmp cleaned and snapshot republished" || bad "stale .tmp handling broken"
+assert "snapshot missing args -> usage, exit 1" 1 "Usage: .* snapshot" -- "$SCRIPT" snapshot
+assert "snapshot unwritable output -> fails"    1 "-" -- "$SCRIPT" snapshot /nonexistent-dir/x.txt "L"
+
+echo "=== snapshot: du fallback chain ==="
+export PODMAN_MODE=nounshare
+assert "unshare fails -> falls back to plain du" 0 "PODMAN_SIZE=$((7*GB))" -- "$SCRIPT" snapshot "$T/out/s2.txt" "L2"
+export DU_FAIL=1
+unset DU_FAKE_SIZE
+assert "unshare and du both fail -> PODMAN_SIZE=unknown" 0 "PODMAN_SIZE=unknown" -- "$SCRIPT" snapshot "$T/out/s3.txt" "L3"
+grep -q "  unknown" "$T/out/s3.txt" && ok "human-readable section shows unknown, not garbage" || bad "unknown not rendered plainly"
+assert "compare with PODMAN_SIZE=unknown still reports FS numbers" 0 "Net space freed" -- "$SCRIPT" compare "$T/out/s3.txt" "$T/out/s2.txt" "$T/out/s2.txt"
+OUT=$("$SCRIPT" compare "$T/out/s3.txt" "$T/out/s2.txt" "$T/out/s2.txt")
+grep -qF "not measured" <<<"$OUT" && ok "podman deltas degrade to 'not measured'" || bad "podman deltas not degraded"
+grep -qE "Removed by reset .*not measured" <<<"$OUT" && ok "podman delta line degraded, not omitted" || bad "podman delta line wrong"
+grep -qF "could not measure the podman storage size" <<<"$OUT" && ok "warning explains the degradation" || bad "degradation warning missing"
+unset DU_FAIL PODMAN_MODE
+
+echo "=== partial du (prints an undercount, exits non-zero) ==="
+export PODMAN_MODE=nounshare DU_PARTIAL=1
+assert "partial du -> PODMAN_SIZE=unknown (not the undercount)" 0 "PODMAN_SIZE=unknown" -- "$SCRIPT" snapshot "$T/out/s8.txt" "L8"
+grep -q "PODMAN_SIZE=12345" "$T/out/s8.txt" && bad "undercounted du total was recorded" || ok "undercounted total rejected"
+unset DU_PARTIAL PODMAN_MODE
+export DU_FAKE_SIZE=$((7*GB))
+
+echo "=== broken podman (storage so corrupted that podman itself fails) ==="
+export PODMAN_MODE=broken
+assert "check with broken podman -> exit 2 + meaningful error" 2 "ERROR: podman is not functional" -- "$SCRIPT" check
+printf 'stale data from a previous run\n' > "$T/out/s4.txt"
+assert "snapshot with broken podman -> exit 2 + warning" 2 "warning: podman is not functional" -- "$SCRIPT" snapshot "$T/out/s4.txt" "L4"
+[ ! -e "$T/out/s4.txt" ] && ok "snapshot removed the stale file and wrote nothing" || bad "stale snapshot file left behind"
+export PODMAN_MODE=brokendf
+assert "snapshot survives 'podman system df' failing" 0 "FS_AVAIL=" -- "$SCRIPT" snapshot "$T/out/s5.txt" "L5"
+grep -q "(podman system df failed)" "$T/out/s5.txt" && ok "system-df failure noted inside snapshot" || bad "system-df failure not noted"
+grep -qE "^FS_AVAIL=[0-9]+" "$T/out/s5.txt" && ok "partial-podman snapshot still valid for compare" || bad "partial snapshot lacks FS_AVAIL"
+unset PODMAN_MODE
+
+echo "=== dead unrelated mount: df -h fails but snapshot survives ==="
+export DF_H_FAIL=1
+assert "snapshot survives df -h failure" 0 "FS_AVAIL=" -- "$SCRIPT" snapshot "$T/out/s7.txt" "L7"
+grep -q "(df -h failed" "$T/out/s7.txt" && ok "df -h failure noted in snapshot" || bad "df -h failure not noted"
+grep -qE "^PODMAN_SIZE=[0-9]+" "$T/out/s7.txt" && ok "df-h-fail snapshot still valid for compare" || bad "df-h-fail snapshot invalid"
+unset DF_H_FAIL
+
+echo "=== compare: exact math end-to-end via generated snapshots ==="
+gen() { # avail-gb podman-gb outfile
+  DF_FAKE_AVAIL=$(( $1*GB )) DU_FAKE_SIZE=$(( $2*GB )) "$SCRIPT" snapshot "$3" "GEN" > /dev/null
+}
+gen 100 500 "$T/out/before.txt"
+gen 580  20 "$T/out/afterreset.txt"
+gen 430 170 "$T/out/afterbuild.txt"
+OUT=$("$SCRIPT" compare "$T/out/before.txt" "$T/out/afterreset.txt" "$T/out/afterbuild.txt") || bad "compare exited non-zero"
+expect() { grep -qF "$2" <<<"$OUT" && ok "compare: $1" || bad "compare: $1 (wanted '$2')"; }
+expect "net freed = 330GB"          "330.00GiB"
+expect "build cost = 150GB"         "150.00GiB"
+expect "removed by reset = 480GB"   "Removed by reset (BeforeReset - AfterReset):  480.00GiB"
+expect "net podman change = -330GB" "Net change      (AfterBuild - BeforeReset):   -330.00GiB"
+grep -qE "Before reset: +100.00GiB" <<<"$OUT" && ok "compare: before-reset avail 100GB" || bad "compare: before-reset avail"
+
+echo "=== compare: negative freed (build bigger than what reset freed) ==="
+gen 100 100 "$T/out/n1.txt"; gen 120 10 "$T/out/n2.txt"; gen 90 40 "$T/out/n3.txt"
+OUT=$("$SCRIPT" compare "$T/out/n1.txt" "$T/out/n2.txt" "$T/out/n3.txt")
+grep -qF -- "-10.00GiB" <<<"$OUT" && ok "negative delta rendered with sign" || bad "negative delta rendering"
+
+echo "=== compare: GITHUB_STEP_SUMMARY markdown ==="
+export GITHUB_STEP_SUMMARY="$T/out/summary.md"; : > "$GITHUB_STEP_SUMMARY"
+"$SCRIPT" compare "$T/out/before.txt" "$T/out/afterreset.txt" "$T/out/afterbuild.txt" > /dev/null
+grep -qF "| Net space freed (AfterBuild - BeforeReset) | 330.00GiB |" "$GITHUB_STEP_SUMMARY" && ok "markdown table row correct" || bad "markdown table row"
+grep -qF "## Podman storage maintenance summary" "$GITHUB_STEP_SUMMARY" && ok "markdown header present" || bad "markdown header"
+unset GITHUB_STEP_SUMMARY
+rm -f "$T/out/summary.md"
+"$SCRIPT" compare "$T/out/before.txt" "$T/out/afterreset.txt" "$T/out/afterbuild.txt" > /dev/null
+[ ! -e "$T/out/summary.md" ] && ok "no summary file written when env unset" || bad "summary written without env"
+
+echo "=== compare: degradation is per-delta and keeps measured values ==="
+gen 100 500 "$T/out/g_r.txt"; gen 430 170 "$T/out/g_x.txt"
+printf 'FS_AVAIL=%s\nPODMAN_SIZE=unknown\n' $((100*GB)) > "$T/out/g_b.txt"
+OUT=$("$SCRIPT" compare "$T/out/g_b.txt" "$T/out/g_r.txt" "$T/out/g_x.txt"); rc=$?
+[ "$rc" = 0 ] && ok "degraded compare still exits 0" || bad "degraded compare exit $rc"
+grep -qE "Added by build .*[0-9]+\.[0-9]+.iB" <<<"$OUT" && ok "computable delta keeps a real number" || bad "computable delta was blanked"
+grep -qE "Removed by reset .*not measured" <<<"$OUT" && ok "affected delta says not measured" || bad "affected delta not degraded"
+grep -qE "After  reset: +[0-9]+\.[0-9]+.iB" <<<"$OUT" && ok "measured sizes still shown" || bad "measured sizes were blanked"
+grep -qE "Before reset: +not measured" <<<"$OUT" && ok "unmeasured size labelled consistently" || bad "unmeasured size wording"
+printf 'FS_AVAIL=%s\nPODMAN_SIZE=abc\n' $((100*GB)) > "$T/out/g_bad.txt"
+assert "garbage PODMAN_SIZE -> skip, exit 2 (malformed, not degraded)" 2 "skipping comparison" -- "$SCRIPT" compare "$T/out/g_bad.txt" "$T/out/g_r.txt" "$T/out/g_x.txt"
+
+echo "=== compare: degraded podman metrics reach the step summary ==="
+export GITHUB_STEP_SUMMARY="$T/out/degsum.md"; : > "$GITHUB_STEP_SUMMARY"
+"$SCRIPT" compare "$T/out/s3.txt" "$T/out/s2.txt" "$T/out/s2.txt" > /dev/null
+grep -qF "| Removed by reset (BeforeReset - AfterReset) | not measured |" "$GITHUB_STEP_SUMMARY" && ok "markdown shows 'not measured'" || bad "markdown degradation missing"
+grep -qE "^\| Net space freed .* \| -?[0-9.]+[KMGT]?i?B \|$" "$GITHUB_STEP_SUMMARY" && ok "markdown still reports FS metric" || bad "markdown lost FS metric"
+unset GITHUB_STEP_SUMMARY
+
+echo "=== compare: bad inputs ==="
+assert "compare missing 3rd arg -> usage, exit 1" 1 "Usage: .* compare" -- "$SCRIPT" compare "$T/out/before.txt" "$T/out/afterreset.txt"
+assert "compare with missing file -> skips, exit 2" 2 "skipping comparison" -- "$SCRIPT" compare /nope1 /nope2 /nope3
+printf 'GARBAGE\n' > "$T/out/malformed.txt"
+assert "compare with malformed snapshot -> skips, exit 2" 2 "skipping comparison" -- "$SCRIPT" compare "$T/out/malformed.txt" "$T/out/afterreset.txt" "$T/out/afterbuild.txt"
+printf 'FS_AVAIL=notanumber\nPODMAN_SIZE=123\n' > "$T/out/badnum.txt"
+assert "compare with non-numeric FS_AVAIL -> skips, exit 2" 2 "skipping comparison" -- "$SCRIPT" compare "$T/out/badnum.txt" "$T/out/afterreset.txt" "$T/out/afterbuild.txt"
+printf 'FS_AVAIL=123abc\nPODMAN_SIZE=123\n' > "$T/out/trailing.txt"
+assert "compare with trailing-garbage FS_AVAIL -> skips, exit 2" 2 "skipping comparison" -- "$SCRIPT" compare "$T/out/trailing.txt" "$T/out/afterreset.txt" "$T/out/afterbuild.txt"
+printf 'FS_AVAIL=1\nFS_AVAIL=2\nPODMAN_SIZE=3\n' > "$T/out/dup.txt"
+assert "compare with duplicated FS_AVAIL -> skips, exit 2" 2 "skipping comparison" -- "$SCRIPT" compare "$T/out/dup.txt" "$T/out/afterreset.txt" "$T/out/afterbuild.txt"
+OUT=$("$SCRIPT" compare "$T/out/before.txt" "$T/out/afterreset.txt" "$T/out/afterbuild.txt")
+grep -qF "330.00GiB" <<<"$OUT" && ok "valid files still compared after guard added" || bad "guard broke the happy path"
+export GITHUB_STEP_SUMMARY="$T/out/skipsum.md"; : > "$GITHUB_STEP_SUMMARY"
+"$SCRIPT" compare /nope1 /nope2 /nope3 > /dev/null || true
+grep -qF "Comparison skipped" "$GITHUB_STEP_SUMMARY" && ok "skip note written to step summary" || bad "skip note missing from step summary"
+unset GITHUB_STEP_SUMMARY
+
+echo "=== human(): numfmt-missing fallback ==="
+mkdir -p "$T/nofmt"
+for tool in bash grep head tail cut awk tee date tr cat sed; do ln -sf "$(command -v $tool)" "$T/nofmt/"; done
+ln -sf "$T/bin/podman" "$T/bin/df" "$T/bin/du" "$T/nofmt/"
+OUT=$(PATH="$T/nofmt" DF_FAKE_AVAIL=$((60*GB)) "$SCRIPT" check) && \
+  grep -qF "$((60*GB)) bytes" <<<"$OUT" && ok "no numfmt -> raw bytes fallback" || bad "no-numfmt fallback :: $OUT"
+
+echo "=== graphroot path with spaces ==="
+mkdir -p "$T/graph root with spaces"
+sed "s|$T/graphroot|$T/graph root with spaces|" "$T/bin/podman" > "$T/bin/podman.tmp" && mv "$T/bin/podman.tmp" "$T/bin/podman" && chmod +x "$T/bin/podman"
+assert "snapshot with spaces in graphroot" 0 "GRAPHROOT=$T/graph root with spaces" -- env DF_FAKE_AVAIL=$((100*GB)) DU_FAKE_SIZE=$((7*GB)) "$SCRIPT" snapshot "$T/out/s6.txt" "L6"
+assert "check with spaces in graphroot"    0 "^OK:" -- env DF_FAKE_AVAIL=$((100*GB)) "$SCRIPT" check
+
+echo
+echo "================================"
+echo "RESULT: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/.github/workflows/build-and-publish-wkdev-sdk-image.yaml
+++ b/.github/workflows/build-and-publish-wkdev-sdk-image.yaml
@@ -35,6 +35,7 @@ jobs:
 
     steps:
     - name: Checkout repository
+      id: checkout
       uses: actions/checkout@v4
 
     - name: Log in to GitHub Container Registry
@@ -79,10 +80,8 @@ jobs:
 
     - name: Build image
       run: |
-        podman build --jobs $(nproc) --build-context scripts=./scripts \
-          --build-arg WKDEV_SDK_VERSION=${{ env.VERSION }} \
-          -t ${{ env.IMAGE_WITH_TAG }}_${{ matrix.arch }} --arch=${{ matrix.arch }} images/wkdev_sdk
-        podman image list
+        ./.github/scripts/build-wkdev-sdk-image.sh "${{ env.VERSION }}" \
+          "${{ env.IMAGE_WITH_TAG }}_${{ matrix.arch }}" "${{ matrix.arch }}"
 
     - name: Test image
       run: |
@@ -100,6 +99,10 @@ jobs:
         (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
       run: podman push ${{ env.IMAGE_WITH_TAG }}_${{ matrix.arch }}
 
+    # Removes the test container and home directory from this run, plus any leftovers from previous crashed runs.
+    # The image we just built is kept as build cache in case there is a new push to this PR; only the images from
+    # older pushes to this same PR are deleted.
+    # Anything else left in podman storage is reclaimed by the daily maintenance workflow when disk runs low.
     - name: Clean up test artifacts
       if: always()
       run: |
@@ -107,12 +110,32 @@ jobs:
           podman rm --force ${{ env.CONTAINER }} 2>/dev/null || true
           rm -rf ${HOME}/${{ env.CONTAINER }}-home || true
         fi
-        # Clean up any leftover containers and home directories from previous failed runs
         podman ps -a --filter "name=^wkdev-" --format "{{.Names}}" | xargs -r podman rm --force 2>/dev/null || true
         find ${HOME} -maxdepth 1 -type d -name "wkdev-*-home" -exec rm -rf {} + 2>/dev/null || true
-        # Reclaim the freshly built image; per-PR-commit cadence would otherwise grow
-        # the self-hosted runner's image store without bound.
-        podman rmi --force ${{ env.IMAGE_WITH_TAG }}_${{ matrix.arch }} 2>/dev/null || true
+        # Only prune the older images once this build produced its own image.
+        # If the build failed (or never ran, leaving IMAGE_WITH_TAG empty),
+        # the image from the previous push is the best cache the next push
+        # has, so keep everything and leave the reclamation to the
+        # maintenance workflow.
+        CURRENT_IMAGE="${{ env.IMAGE_WITH_TAG }}_${{ matrix.arch }}"
+        if [ "${{ github.event_name }}" = "pull_request" ] && podman image exists "${CURRENT_IMAGE}"; then
+          podman images --format '{{.Repository}}:{{.Tag}}' \
+            | grep -F "${IMAGE_NAME}:pr-${{ github.event.pull_request.number }}-" \
+            | grep -v -F "${CURRENT_IMAGE}" \
+            | xargs -r podman rmi --force 2>/dev/null || true
+        fi
+
+    # Storage reclamation happens via the daily scheduled podman-storage-maintenance workflow,
+    # but that workflow can only reach runners listed in its matrix (entries are runner names,
+    # used as unique labels). A runner missing from it never gets its storage reset, so audit
+    # that this machine is listed and fail the job if not so this gets investigated and fixed.
+    # Skipped when the checkout failed: without the repo there is nothing to audit against,
+    # and a false "runner not covered" error would mask the real failure.
+    - name: Fail if this runner is missing from the maintenance matrix
+      if: always() && steps.checkout.outcome == 'success'
+      env:
+        RUNNER_NAME: ${{ runner.name }}
+      run: ./.github/scripts/assert-runner-in-maintenance-matrix.sh
 
   deploy:
     runs-on: [self-hosted, x64]
@@ -128,13 +151,30 @@ jobs:
       REGISTRY_TAG: ${{ needs.build.outputs.registry_tag }}
 
     steps:
+    - name: Checkout repository
+      id: checkout
+      uses: actions/checkout@v4
+
     - name: Log in to GitHub Container Registry
       run: echo "${{ secrets.GITHUB_TOKEN }}" | skopeo login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
-    - name: Resolve registry coordinates
+    - name: Resolve registry coordinates and local image state
       run: |
-        echo "GHCR_REPO=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
-        echo "IMAGE_WITH_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${IMAGE_NAME}:${REGISTRY_TAG}" >> $GITHUB_ENV
+        GHCR_REPO="${GITHUB_REPOSITORY_OWNER,,}"
+        IMAGE_WITH_TAG="ghcr.io/${GHCR_REPO}/${IMAGE_NAME}:${REGISTRY_TAG}"
+        echo "GHCR_REPO=${GHCR_REPO}" >> $GITHUB_ENV
+        echo "IMAGE_WITH_TAG=${IMAGE_WITH_TAG}" >> $GITHUB_ENV
+
+        # The amd64 build may have run on this machine and kept its image as
+        # cache. Remember which images are already here so cleanup keeps them.
+        # This may also keep an image left by a cancelled deploy; the regular
+        # maintenance workflow will remove it later.
+        for arch in amd64 arm64; do
+          if podman image exists "${IMAGE_WITH_TAG}_${arch}"; then
+            echo "${IMAGE_WITH_TAG}_${arch} is already in local storage: it won't be removed by this job"
+            echo "PREEXISTING_${arch}=1" >> $GITHUB_ENV
+          fi
+        done
 
     - name: Validate all architecture images exist in registry
       id: validate
@@ -214,9 +254,19 @@ jobs:
         podman manifest push --all ${{ env.IMAGE_WITH_TAG }} docker://${{ env.IMAGE_WITH_TAG }}
 
     - name: Remove local artifacts produced by this deploy
+      if: always()
       run: |
         podman manifest rm ${{ env.IMAGE_WITH_TAG }} 2>/dev/null || true
-        podman rmi --force ${{ env.IMAGE_WITH_TAG }}_amd64 ${{ env.IMAGE_WITH_TAG }}_arm64 2>/dev/null || true
+        # Only the copies this job pulled: the ones that were already here are
+        # kept for the build cache (see the coordinate-resolution step above).
+        for arch in amd64 arm64; do
+          preexisting="PREEXISTING_${arch}"
+          if [ -n "${!preexisting:-}" ]; then
+            echo "Keeping ${IMAGE_WITH_TAG}_${arch}: it was in local storage before this job"
+            continue
+          fi
+          podman rmi --force "${IMAGE_WITH_TAG}_${arch}" 2>/dev/null || true
+        done
 
     - name: Comment on PR with deployed image
       if: github.event_name == 'pull_request'
@@ -226,3 +276,11 @@ jobs:
         message: |
           Test image deployed to the registry: `${{ env.IMAGE_WITH_TAG }}`
           Create a container from it with: `wkdev-create --version ${{ env.REGISTRY_TAG }}`
+
+    # See comment on this same step for the build: job
+    # Keep it as the last step: a drift failure shouldn't rob the PR author of the image comment above.
+    - name: Fail if this runner is missing from the maintenance matrix
+      if: always() && steps.checkout.outcome == 'success'
+      env:
+        RUNNER_NAME: ${{ runner.name }}
+      run: ./.github/scripts/assert-runner-in-maintenance-matrix.sh

--- a/.github/workflows/podman-storage-maintenance.yaml
+++ b/.github/workflows/podman-storage-maintenance.yaml
@@ -1,0 +1,181 @@
+name: Podman storage maintenance
+
+# Reclaims podman storage on the self-hosted runners: a full podman storage
+# wipe (podman system reset) followed by a rebuild of the image so the build
+# cache stays warm.
+#
+# It runs from two entry points:
+#   - schedule: daily threshold-check, so a runner that filled up gets
+#     reset at most ~24 hours later
+#   - manual workflow_dispatch (optionally with force=true to reset even
+#     when free space is above the threshold)
+#
+# Unless forced, each job first checks free space against the threshold in
+# .github/scripts/disk-usage.sh and exits early doing nothing but reporting
+# disk stats when there is enough space.
+
+on:
+  schedule:
+    # GitHub Actions cron is in UTC. Run the check every night late.
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Reset even if free disk space is above the threshold'
+        type: boolean
+        default: false
+
+env:
+  IMAGE_NAME: wkdev-sdk
+
+jobs:
+  system-reset-and-rebuild:
+    strategy:
+      fail-fast: false
+      # GitHub doesn't support automatically running a job on every runner, so each runner to maintain
+      # must be listed here explicitly. `runner` here is an additional unique label that must be added
+      # to that specific runner in the GitHub UI (Settings -> Actions -> Runners -> <runner> -> Labels)
+      #
+      # IMPORTANT: the unique label MUST be exactly the runner's NAME as shown in the runners list.
+      # The image build workflow checks runner.name against the `runner:` values below (see
+      # scripts/assert-runner-in-maintenance-matrix.sh) and fails its job when the machine it ran
+      # on is missing from this list, so drift can't go unnoticed.
+      # IMPORTANT: When adding a new runner: add its name as a label in the GitHub UI and list it here.
+      # IMPORTANT: When decommissioning a runner remove its entry promptly: a matrix entry whose
+      # label matches no online runner keeps its job queued for ~24h per run. Only that runner's
+      # own maintenance is affected (the concurrency group is per-runner), but the stuck jobs
+      # clutter the Actions view until the entry is removed.
+      matrix:
+        include:
+          - arch: amd64
+            runner: igalia-runner-wkdev-amd64-1
+          - arch: amd64
+            runner: igalia-runner-wkdev-amd64-2
+          - arch: arm64
+            runner: igalia-runner-wkdev-arm64-1
+          - arch: arm64
+            runner: igalia-runner-wkdev-arm64-2
+    runs-on: [self-hosted, "${{ matrix.runner }}"]
+    # Serialize maintenance per machine (an overlapping run, e.g. a manual
+    # dispatch while the scheduled run is active, queues instead). Per-runner
+    # groups on purpose: a job stuck waiting for one unreachable runner must
+    # not delay the maintenance of the healthy ones.
+    concurrency:
+      group: podman-storage-maintenance-${{ matrix.runner }}
+      cancel-in-progress: false
+    # Backstop for a hung reset or rebuild; queue time waiting for an offline
+    # runner is not covered by this (GitHub caps that at ~24h).
+    timeout-minutes: 360
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+    # The unique per-runner label decides where this job lands, and the label
+    # assignment in the GitHub UI can drift: if this machine carries another
+    # machine's label, that other machine is never maintained while this one
+    # is reset twice - and the build-side audit cannot notice, because it
+    # only checks that runner names are listed in the matrix. Verify the
+    # name/label pairing before anything else: everything below, starting
+    # with the storage reset, must run on the machine the matrix names.
+    - name: Fail unless this job landed on the machine its matrix entry names
+      env:
+        RUNNER_NAME: ${{ runner.name }}
+        MATRIX_RUNNER: ${{ matrix.runner }}
+      run: |
+        if [ "$RUNNER_NAME" != "$MATRIX_RUNNER" ]; then
+          echo "::error title=Maintenance job landed on the wrong machine::The matrix entry '${MATRIX_RUNNER}' ran on runner '${RUNNER_NAME}', so the unique label '${MATRIX_RUNNER}' is attached to the wrong machine in the runner settings (Settings -> Actions -> Runners). Fix the label assignment: until then '${MATRIX_RUNNER}' is never maintained and '${RUNNER_NAME}' is maintained twice."
+          exit 1
+        fi
+        echo "Runner name '${RUNNER_NAME}' matches its matrix entry."
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Disk usage before reset
+      # Snapshots live in runner.temp, which the runner empties at the start
+      # of every job: snapshots leftover from a previous run can never leak
+      # into the uploaded artifact, no matter which steps run or fail.
+      # Tolerate a failing snapshot (podman too broken to report stats): the
+      # check step below fails the same way then, and its failure is what
+      # triggers the reset that repairs podman.
+      run: |
+        ./.github/scripts/disk-usage.sh snapshot "${RUNNER_TEMP}/disk-beforesystemreset.txt" "BEFORE SYSTEM RESET (${{ matrix.runner }})" \
+          || echo "continuing to the check step regardless"
+
+    - name: Check whether a reset is needed
+      id: check
+      # The else branch catches both a low-disk result and a check that
+      # *errored* (exit 2: podman broken by corrupted storage): both mean
+      # this machine needs the reset.
+      run: |
+        if [ "${{ inputs.force }}" = "true" ]; then
+          echo "Reset forced via workflow_dispatch input."
+          echo "reset=true" >> $GITHUB_OUTPUT
+        elif ./.github/scripts/disk-usage.sh check; then
+          echo "reset=false" >> $GITHUB_OUTPUT
+          {
+            echo "## Podman storage maintenance (${{ matrix.runner }})"
+            echo
+            echo "Free disk space is above the threshold: reset skipped."
+          } >> $GITHUB_STEP_SUMMARY
+        else
+          echo "reset=true" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Reset podman storage
+      if: steps.check.outputs.reset == 'true'
+      # Unlike prune, a full reset also reclaims buildah leftovers and corrupted
+      # storage; the runners are CI-dedicated, so losing volumes/networks is fine
+      run: podman system reset --force
+
+    - name: Log in to GitHub Container Registry
+      if: steps.check.outputs.reset == 'true'
+      # The reset wipes the runtime dir where the login credentials are stored, so do the login after the reset
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+
+    - name: Disk usage after reset
+      if: steps.check.outputs.reset == 'true'
+      # No failure tolerance from here on: after the reset podman and the
+      # filesystem inspection must work, so a failing snapshot means the
+      # reset did not fix this machine. Failure of only the optional du
+      # measurement of the graphroot does not fail the snapshot: it is
+      # recorded as PODMAN_SIZE=unknown and only makes the podman storage
+      # deltas that need it read "not measured" in the comparison below.
+      run: ./.github/scripts/disk-usage.sh snapshot "${RUNNER_TEMP}/disk-aftersystemreset.txt" "AFTER SYSTEM RESET (${{ matrix.runner }})"
+
+    - name: Rebuild image to warm the build cache
+      if: steps.check.outputs.reset == 'true'
+      # Same shared build script as the image build workflow: the cache is
+      # only warm if both build the exact same way.
+      run: |
+        VERSION=$(./scripts/helpers/print-sdk-version)
+        ./.github/scripts/build-wkdev-sdk-image.sh "${VERSION}" \
+          "ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${IMAGE_NAME}:${VERSION}_${{ matrix.arch }}" "${{ matrix.arch }}"
+
+    - name: Disk usage after rebuild and summary
+      if: steps.check.outputs.reset == 'true'
+      # Only the documented skip (exit 2: a snapshot is missing/invalid, e.g.
+      # the before-reset one when podman was broken) is tolerated; any other
+      # compare failure is unexpected and fails the step.
+      run: |
+        ./.github/scripts/disk-usage.sh snapshot "${RUNNER_TEMP}/disk-aftersystemresetandbuild.txt" "AFTER SYSTEM RESET AND BUILD (${{ matrix.runner }})"
+        rc=0
+        ./.github/scripts/disk-usage.sh compare \
+          "${RUNNER_TEMP}/disk-beforesystemreset.txt" \
+          "${RUNNER_TEMP}/disk-aftersystemreset.txt" \
+          "${RUNNER_TEMP}/disk-aftersystemresetandbuild.txt" || rc=$?
+        if [ "$rc" = 2 ]; then
+          echo "comparison skipped, see warning above"
+        elif [ "$rc" != 0 ]; then
+          echo "compare failed unexpectedly (exit $rc)"
+          exit "$rc"
+        fi
+
+    - name: Upload disk usage snapshots
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: disk-snapshots-${{ matrix.runner }}
+        path: ${{ runner.temp }}/disk-*systemreset*.txt
+        retention-days: 90

--- a/.github/workflows/test-ci-helper-scripts.yaml
+++ b/.github/workflows/test-ci-helper-scripts.yaml
@@ -1,0 +1,29 @@
+name: Test CI helper scripts
+
+# Regression tests for the scripts in .github/scripts. They stub podman and
+# the disk tools, so they run in seconds on a hosted runner and touch nothing
+# outside a temp directory. Also triggered by changes to the maintenance
+# workflow, because the assert-runner test validates its real matrix.
+
+on:
+  pull_request:
+    paths:
+      - '.github/scripts/**'
+      - '.github/workflows/podman-storage-maintenance.yaml'
+      - '.github/workflows/test-ci-helper-scripts.yaml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Test disk-usage.sh
+      run: ./.github/scripts/tests/test-disk-usage.sh
+
+    - name: Test assert-runner-in-maintenance-matrix.sh
+      run: ./.github/scripts/tests/test-assert-runner-in-maintenance-matrix.sh


### PR DESCRIPTION
The CI jobs already clean up after themselves at the end of each run, but that isn't enough to keep the disk under control: when a build is aborted mid-way (for example, a new push to a PR cancels the build that was already running), it dies before its cleanup steps run and leaves behind half-built images and buildah containers that nothing ever removes. Over time the runners fill up anyway.

This adds a workflow that runs daily (plus manually, with an optional force=true input) on every runner. If the runner has less than 50GiB free, or if the reset is forced, it wipes the podman storage with `podman system reset` and immediately rebuilds the wkdev-sdk image to warm the build cache.
Otherwise it just records the disk usage stats, which over time gives us a daily record of how fast each disk fills. A reset is used instead of a prune because it also recovers from corrupted storage and removes buildah leftovers without relying on podman bookkeeping being intact.

Since GitHub Actions can't target "all runners with a label", the matrix lists every machine by a unique label equal to its runner name. The build and deploy jobs check their own runner name against that list and fail loudly if it's missing, so a forgotten runner shows up as a red check instead of silently never being cleaned.

The maintenance jobs also verify that they landed on the machine each matrix entry names, catching a unique label assigned to the wrong runner before the wrong machine is reset. Concurrency is scoped per runner, so an unavailable machine does not delay maintenance of the healthy ones.

With disk usage now under control, the build job can also stop deleting the image it just built. Deleting it threw away the cache that makes the next push to the same PR build much faster. Instead, only the older images of the same PR are removed. Images from closed PRs and other leftovers are left for the maintenance workflow. Release builds keep their image too: it's the best possible cache for the PR builds that follow.

Older PR images are only removed when the current image exists locally, so a failed build cannot discard the last useful cache. The deploy job remembers which images were already present locally, so it cleans only its own artifacts to ensure that it doesn't discard a build cache that it did not create. The cleanup runs with "if: always()", so architecture images newly pulled to assemble the manifest are reclaimed even when the manifest push fails.

The helper scripts live in .github/scripts: disk-usage.sh owns the 50GiB threshold and the before/after disk reports (shown in the job summary and kept as a 90-day artifact), build-wkdev-sdk-image.sh is shared by the real build and the cache-warming rebuild so both always build the same way, and assert-runner-in-maintenance-matrix.sh is the runner coverage check shared by the build and deploy jobs. They are careful about degraded machines: a broken podman is reported as such and treated as "maintenance needed", missing or malformed snapshots skip the comparison instead of inventing numbers, unavailable optional measurements are reported as "not measured", and no failure can leave a partial or stale report behind.

The helper scripts have regression tests that stub podman and the disk tools, so their success, failure, and degraded-machine paths run in seconds.